### PR TITLE
Reset webcam and screen share state on leaving

### DIFF
--- a/apps/client/src/features/server/voice/actions.ts
+++ b/apps/client/src/features/server/voice/actions.ts
@@ -163,6 +163,7 @@ export const leaveVoice = async (): Promise<void> => {
   }
 
   setCurrentVoiceChannelId(undefined);
+  updateOwnVoiceState({ webcamEnabled: false, sharingScreen: false });
   setPinnedCard(undefined);
 
   const client = getTRPCClient();


### PR DESCRIPTION
Camera and screen share are always off when joining a voice channel. There was a bug where the state was not being cleared when leaving a voice channel. When joining again the button for camera/screen share would use the state before leaving and activating the camera again would require clicking the button twice.