### PR TITLE
Fixed: Voice Control Indication

### DIFF
--- a/apps/client/src/components/voice-provider/hooks/use-voice-controls.ts
+++ b/apps/client/src/components/voice-provider/hooks/use-voice-controls.ts
@@ -110,9 +110,15 @@ const useVoiceControls = ({
       await trpc.voice.updateState.mutate({
         webcamEnabled: newState
       });
-    } catch (error) {
+     } catch (error) {
       updateOwnVoiceState({ webcamEnabled: false });
-      await trpc.voice.updateState.mutate({ webcamEnabled: false }).catch(() => {});
+
+      try {
+        await trpc.voice.updateState.mutate({ webcamEnabled: false });
+      } catch {
+        // ignore
+      }
+
       toast.error(getTrpcError(error, 'Failed to update webcam state'));
     }
   }, [
@@ -143,9 +149,13 @@ const useVoiceControls = ({
           stopScreenShareStream();
           updateOwnVoiceState({ sharingScreen: false });
 
-          await trpc.voice.updateState.mutate({
-            sharingScreen: false
-          }).catch(() => {});
+          try {
+            await trpc.voice.updateState.mutate({
+              sharingScreen: false
+            });
+          } catch {
+            // ignore
+          }
         };
       } else {
         stopScreenShareStream();
@@ -156,7 +166,13 @@ const useVoiceControls = ({
       });
     } catch (error) {
       updateOwnVoiceState({ sharingScreen: false });
-      await trpc.voice.updateState.mutate({ sharingScreen: false }).catch(() => {});
+
+      try {
+        await trpc.voice.updateState.mutate({ sharingScreen: false });
+      } catch {
+        // ignore
+      }
+
       toast.error(getTrpcError(error, 'Failed to update screen share state'));
     }
   }, [


### PR DESCRIPTION
**Issue**: If a user who does not have a webcam attempts to press the camera button, the button will turn green to indicate the webcam is ON despite the message "_Requested device not found_" being rendered. A similar issue arises  when pressing the button to share screens, as if the user decides to cancel they will prompted with a "_Permission denied by user_" message, yet the screen share icon will still remain blue and the screen itself will split to indicate sharing content.

**Fix:** Added rollback and fail closed cleanup for the webcam/screenshare controls on TRPC mutation errors.