### PR TITLE
feat: build and push linux arm64 docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -60,7 +65,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/sharkord:latest


### PR DESCRIPTION
### Motivation
Arm64 binaries are already being built in each release, but only the amd64 image is being pushed to dockerhub. This should now push these and make it simpler to run on raspberry pi's etc with the existing docker compose.

### Changes
- Includes `arm64` platform in the manual release GHA
- Dockerfile uses `TARGETARCH` to copy the correct binary before building and pushing docker image
- Dockerfile uses multi-stage build so final image only copies the appropriate binary.