### PR TITLE
feature: add server name to login screen

### DIFF
--- a/apps/client/src/screens/connect/index.tsx
+++ b/apps/client/src/screens/connect/index.tsx
@@ -116,8 +116,13 @@ const Connect = memo(() => {
     <div className="flex flex-col gap-2 justify-center items-center h-full">
       <Card className="w-full max-w-sm">
         <CardHeader>
-          <CardTitle className="flex justify-center">
+          <CardTitle className="flex flex-col items-center gap-2 text-center">
             <img src={logoSrc} alt="Sharkord" className="w-32 h-32" />
+            {info?.name && (
+              <span className="text-xl font-bold leading-tight">
+                {info.name}
+              </span>
+            )}
           </CardTitle>
         </CardHeader>
         <CardContent className="flex flex-col gap-4">


### PR DESCRIPTION
Currently the login screen shows the server logo and description, but not the name. 
This PR adds the server name below the logo using the existing info.name field.

<img width="627" height="639" alt="изображение" src="https://github.com/user-attachments/assets/7e6ac87d-254d-4492-9e6f-13ead14fb535" />
