### PR TITLE
Bug (#170) - Fixed sending messages with only an emote in.

### DIFF
--- a/packages/shared/src/helpers/is-empty-message.ts
+++ b/packages/shared/src/helpers/is-empty-message.ts
@@ -3,7 +3,7 @@ const isEmptyMessage = (content: string): boolean => {
   if (!content) return true;
 
   const text = content
-    .replace(/<[^>]+>/g, '')
+    .replace(/<p\b[^>]*>(?:\s|&nbsp;|<br\b[^>]*>)*<\/p>/gi, '')
     .replace(/&nbsp;/g, ' ')
     .trim();
 


### PR DESCRIPTION
Fixed sending messages with only emotes, changed the regex to just detect empty p tags or ones with line breaks/br tags in them.

Bug ref: #170 