### PR TITLE
Support cross-filesystem file operations

### DIFF
--- a/apps/server/src/utils/file-manager.ts
+++ b/apps/server/src/utils/file-manager.ts
@@ -36,6 +36,20 @@ const md5File = async (path: string): Promise<string> => {
   return hash.digest('hex');
 };
 
+const moveFile = async (src: string, dest: string) => {
+  try {
+    await fs.rename(src, dest);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (err: any) {
+    if (err.code === 'EXDEV') {
+      await fs.copyFile(src, dest);
+      await fs.unlink(src);
+    } else {
+      throw err;
+    }
+  }
+};
+
 class TemporaryFileManager {
   private temporaryFiles: TTempFile[] = [];
   private timeouts: {
@@ -77,8 +91,7 @@ class TemporaryFileManager {
       userId
     };
 
-    await fs.copyFile(filePath, tempFile.path);
-    await fs.unlink(filePath);
+    await moveFile(filePath, tempFile.path);
 
     this.temporaryFiles.push(tempFile);
 
@@ -214,8 +227,7 @@ class FileManager {
     const fileName = await this.getUniqueName(tempFile.originalName);
     const destinationPath = path.join(PUBLIC_PATH, fileName);
 
-    await fs.copyFile(tempFile.path, destinationPath);
-    await fs.unlink(tempFile.path);
+    await moveFile(tempFile.path, destinationPath);
     await this.removeTemporaryFile(tempFileId, true);
 
     const bunFile = Bun.file(destinationPath);


### PR DESCRIPTION
Fixes EXDEV error when uploading a file and thus allows symlinking the public folder to other locations such as an NFS share.