### PR TITLE
feat(207): build and push image development image

### DIFF
--- a/.github/actions/build-sharkord/action.yml
+++ b/.github/actions/build-sharkord/action.yml
@@ -1,0 +1,33 @@
+name: Build Sharkord
+description: Checkout the repository, install Bun dependencies, and build server artifacts.
+
+inputs:
+  bun_version:
+    description: Bun version to install
+    required: false
+    default: 1.3.5
+  bump:
+    description: Version bump mode (none, patch, minor, major)
+    required: false
+    default: none
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Bun
+      uses: oven-sh/setup-bun@v1
+      with:
+        bun-version: ${{ inputs.bun_version }}
+
+    - name: Install dependencies
+      shell: bash
+      run: bun install
+
+    - name: Build app
+      shell: bash
+      run: |
+        cd apps/server
+        bun run build --bump "${{ inputs.bump }}"

--- a/.github/actions/docker-build-publish/action.yml
+++ b/.github/actions/docker-build-publish/action.yml
@@ -1,0 +1,55 @@
+name: Docker Build And Publish
+description: Set up Docker build tooling, authenticate, and build/push multi-arch images.
+
+inputs:
+  docker_username:
+    description: Docker Hub username
+    required: true
+  docker_password:
+    description: Docker Hub password or token
+    required: true
+  tags:
+    description: Docker image tags (newline separated)
+    required: true
+  labels:
+    description: Docker image labels (newline separated)
+    required: false
+    default: ""
+  context:
+    description: Docker build context path
+    required: false
+    default: "."
+  platforms:
+    description: Target platforms
+    required: false
+    default: linux/amd64,linux/arm64
+  qemu_platforms:
+    description: Platforms to register with QEMU
+    required: false
+    default: arm64
+
+runs:
+  using: composite
+  steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: ${{ inputs.qemu_platforms }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.docker_username }}
+        password: ${{ inputs.docker_password }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: ${{ inputs.context }}
+        platforms: ${{ inputs.platforms }}
+        push: true
+        tags: ${{ inputs.tags }}
+        labels: ${{ inputs.labels }}

--- a/.github/workflows/develop-image.yml
+++ b/.github/workflows/develop-image.yml
@@ -1,0 +1,31 @@
+name: Publish Develop Image
+
+on:
+  push:
+    branches:
+      - development
+  workflow_dispatch:
+
+concurrency:
+  group: docker-develop
+  cancel-in-progress: true
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build project artifacts
+        uses: ./.github/actions/build-sharkord
+
+      - name: Build and publish Docker image
+        uses: ./.github/actions/docker-build-publish
+        with:
+          docker_username: ${{ secrets.DOCKER_USERNAME }}
+          docker_password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: ${{ secrets.DOCKER_USERNAME }}/sharkord:develop
+          labels: |
+            org.opencontainers.image.title=Sharkord
+            org.opencontainers.image.description=Sharkord Server (develop)
+            org.opencontainers.image.source=https://github.com/Sharkord/sharkord
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,51 +22,25 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v1
+      - name: Build project artifacts
+        uses: ./.github/actions/build-sharkord
         with:
-          bun-version: 1.3.5
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Build app
-        run: |
-          cd apps/server
-          bun run build --bump ${{ inputs.bump }}
+          bump: ${{ inputs.bump }}
 
       - name: Get new version
         id: get_version
-        run: echo "::set-output name=version::$(jq -r .version package.json)"
+        run: echo "version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
 
       - name: Identify user
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Build and publish Docker image
+        uses: ./.github/actions/docker-build-publish
         with:
-          platforms: arm64
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
+          docker_username: ${{ secrets.DOCKER_USERNAME }}
+          docker_password: ${{ secrets.DOCKER_PASSWORD }}
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/sharkord:latest
             ${{ secrets.DOCKER_USERNAME }}/sharkord:v${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
### Motivation
Have an up to date docker image which follows the `development` branch. 

### Changes
- Added `develop-image` action to build and publish `sharkord:develop` on every push to development, with optional manual trigger. If new commit is pushed whilst workflow is running the in progress run will cancel in favour of the new run.
- Refactored what would have been duplicate code into reusable actions:
  - `build-sharkord`: Checkout the repository, install Bun dependencies, and build server artifacts.
  - `docker-build-publish`: Set up Docker build tooling, authenticate, and build/push multi-arch images.

### Issues
#207 
