### PR TITLE
Delete the message when deleting all media (if the message has no text) #192

### DIFF
--- a/apps/server/src/routers/files/delete-file.ts
+++ b/apps/server/src/routers/files/delete-file.ts
@@ -3,17 +3,51 @@ import { removeFile } from '../../db/mutations/files';
 import { publishMessage } from '../../db/publishers';
 import { getMessageByFileId } from '../../db/queries/messages';
 import { protectedProcedure } from '../../utils/trpc';
+import { isEmptyMessage } from '@sharkord/shared';
+import { Permission } from '@sharkord/shared';
+import { invariant } from '../../utils/invariant';
+import { db } from '../../db';
+import { messages } from '../../db/schema';
+import { eventBus } from '../../plugins/event-bus';
+import { getFilesByMessageId } from '../../db/queries/files';
+import { eq } from 'drizzle-orm';
 
 const deleteFileRoute = protectedProcedure
   .input(z.object({ fileId: z.number() }))
-  .mutation(async ({ input }) => {
+  .mutation(async ({ input, ctx }) => {
+
     const message = await getMessageByFileId(input.fileId);
 
+    invariant(message, {
+      code: 'NOT_FOUND',
+      message: 'Message not found'
+    });
+
+    invariant(
+      message.userId === ctx.user.id ||
+      (await ctx.hasPermission(Permission.MANAGE_MESSAGES)),
+      {
+        code: 'FORBIDDEN',
+        message: 'You do not have permission to delete this file'
+      }
+    );
+
     await removeFile(input.fileId);
-
-    if (!message) return;
-
+    
     publishMessage(message.id, message.channelId, 'update');
+
+    const files = await getFilesByMessageId(message.id);
+
+    if (isEmptyMessage(message.content) && files.length == 0) {
+      await db.delete(messages).where(eq(messages.id, message.id));
+
+      publishMessage(message.id, message.channelId, 'delete');
+
+      eventBus.emit('message:deleted', {
+        channelId: message.channelId,
+        messageId: message.Id
+      });
+    }
   });
 
 export { deleteFileRoute };


### PR DESCRIPTION
fixes #192

- Added safety check to make sure message still exists in db
- Added Permission check on server side if user is allowed to manage messages or if its his message
- Added check if message contains text or other files, if not delete message aswell

NOTE: 
PR Check for invalid Channel/Category names #212
changes the function name for isEmptyMessage, if #212 will be merged this change needs to accomodate for the different Function name, please leave a comment if thats the case so i can change it