### PR TITLE
Feature #249 - Add tiptap expand/collapse button

### DIFF
--- a/apps/client/src/components/tiptap-input/index.tsx
+++ b/apps/client/src/components/tiptap-input/index.tsx
@@ -5,8 +5,8 @@ import type { TCommandInfo } from '@sharkord/shared';
 import Emoji, { gitHubEmojis } from '@tiptap/extension-emoji';
 import { EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
-import { Smile } from 'lucide-react';
-import { memo, useEffect, useMemo, useRef } from 'react';
+import { ChevronDown, ChevronUp, Smile } from 'lucide-react';
+import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   COMMANDS_STORAGE_KEY,
   CommandSuggestion
@@ -39,6 +39,12 @@ const TiptapInput = memo(
   }: TTiptapInputProps) => {
     const readOnlyRef = useRef(readOnly);
     readOnlyRef.current = readOnly;
+
+    const [isExpanded, setIsExpanded] = useState(false);
+    const [hasOverflow, setHasOverflow] = useState(false);
+    const [isHovering, setIsHovering] = useState(false);
+    const [isFocused, setIsFocused] = useState(false);
+    const editorWrapperRef = useRef<HTMLDivElement>(null);
 
     const customEmojis = useCustomEmojis();
 
@@ -183,14 +189,50 @@ const TiptapInput = memo(
       }
     }, [editor, disabled]);
 
+    // Measure if content overflows (more than ~3 lines) when collapsed
+    useLayoutEffect(() => {
+      if (isExpanded) return;
+      const wrapper = editorWrapperRef.current;
+      const el = wrapper?.firstElementChild as HTMLElement | null;
+      if (el) {
+        setHasOverflow(el.scrollHeight > el.clientHeight);
+      }
+    }, [value, isExpanded]);
+
+    const showExpandButton = hasOverflow || isExpanded;
+
     return (
       <div className="flex flex-1 items-center gap-2 min-w-0">
-        <EditorContent
-          editor={editor}
-          className={`border p-2 rounded w-full min-h-[40px] max-h-[5rem] tiptap overflow-auto ${
-            disabled ? 'opacity-50 cursor-not-allowed bg-muted' : ''
-          }`}
-        />
+        <div
+          ref={editorWrapperRef}
+          className="relative flex min-w-0 flex-1"
+          onMouseEnter={() => setIsHovering(true)}
+          onMouseLeave={() => setIsHovering(false)}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+        >
+          <EditorContent
+            editor={editor}
+            className={`border p-2 rounded w-full min-h-[40px] tiptap overflow-auto relative ${isExpanded ? 'max-h-80' : 'max-h-20'
+              } ${disabled ? 'opacity-50 cursor-not-allowed bg-muted' : ''}`}
+          />
+          {showExpandButton && (isHovering || isFocused) && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="absolute -top-[4px] left-1/2 -translate-y-1/2 -translate-x-1/2 h-5 w-8 shrink-0 rounded border bg-background hover:bg-muted"
+              onClick={() => setIsExpanded((e) => !e)}
+              aria-label={isExpanded ? 'Collapse' : 'Expand'}
+            >
+              {isExpanded ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronUp className="h-4 w-4" />
+              )}
+            </Button>
+          )}
+        </div>
 
         <EmojiPicker onEmojiSelect={handleEmojiSelect}>
           <Button variant="ghost" size="icon" disabled={disabled}>


### PR DESCRIPTION
**Behavior:** 
The expand/collapse button in the tiptap input is shown only when the editor wrapper is hovered or focused (Desktop and mobile support), and still only when there’s enough content to expand (~3 lines) or when the editor is already expanded.

**Visibility:** 
Button is visible when (isHovering || isFocused) and (hasOverflow || isExpanded).

**Hover:** 
onMouseEnter / onMouseLeave on the wrapper control hover visibility (desktop).

**Focus:** 
onFocus / onBlur on the wrapper (using bubbling) control focus visibility so the button appears when the user focuses the editor or any descendant (e.g. the button itself), including on tap/focus on mobile.

**Result:** 
Cleaner default UI (no button when not interacting), same expand/collapse behavior, and the button remains discoverable and usable on touch devices when the field is focused.

Closes #249