### PR TITLE
fix (#198): allow channels with "invisible" names to be selected

### DIFF
--- a/apps/client/src/components/left-sidebar/categories.tsx
+++ b/apps/client/src/components/left-sidebar/categories.tsx
@@ -68,7 +68,7 @@ const Category = memo(({ categoryId }: TCategoryProps) => {
       className="mb-4"
     >
       <div className="mb-1 flex w-full items-center px-2 py-1 text-xs font-semibold text-muted-foreground">
-        <div className="flex w-full items-center gap-1">
+        <div className="flex w-full items-stretch gap-1">
           <IconButton
             variant="ghost"
             size="sm"
@@ -80,7 +80,7 @@ const Category = memo(({ categoryId }: TCategoryProps) => {
             <span
               {...attributes}
               {...listeners}
-              className="cursor-grab active:cursor-grabbing"
+              className="cursor-grab active:cursor-grabbing flex-1"
             >
               {category.name}
             </span>


### PR DESCRIPTION
## Summary
Done by stretching the element with the channels name to take up all of the available space instead sizing it according to the length of the name

Closes #198 

---

## Additional Context
Originally implemented in #212, decided to split the implemented fixed into multiple PRs, according to the contributing guidelines

