### PR TITLE
Fix: Display basic emojis and letters in the emoji grid

### DIFF
--- a/apps/client/src/components/emoji-picker/emoji-data.ts
+++ b/apps/client/src/components/emoji-picker/emoji-data.ts
@@ -32,8 +32,13 @@ const processEmojis = () => {
   }
 
   for (const emoji of gitHubEmojis) {
-    if (!emoji.emoji || !emoji.group) continue;
+    if (!emoji.emoji || emoji.group === undefined || emoji.group === null)
+      continue;
     if (emoji.group === 'components' || emoji.group === 'GitHub') continue;
+
+    if (emoji.group === '' && emoji.name.includes('regional_indicator_'))
+      emoji.group = EMOJI_CATEGORIES[7].id;
+    if (emoji.group === '') emoji.group = EMOJI_CATEGORIES[1].id;
 
     const converted = toTEmojiItem(emoji);
 


### PR DESCRIPTION
## Summary

Closes [280](https://github.com/Sharkord/sharkord/issues/280)

---

## Additional Context

The existing filtering for the emojis in the emoji picker grid is little too strict. Some common emojis in the dataset don't have any group assigned. 

This fixes it by assigning basic emojis into the people group and letter emojis into the symbols group.
