### PR TITLE
feat(#47): initial implementation of session cookies

### DIFF
--- a/apps/server/src/helpers/parse-cookie.ts
+++ b/apps/server/src/helpers/parse-cookie.ts
@@ -1,0 +1,12 @@
+function parseCookie(cookieHeader: string | undefined, name: string) {
+  if (cookieHeader === undefined) { return undefined }
+  const cookies = cookieHeader.split(";").map(v => v.trim());
+  for (const c of cookies) {
+    if (c.startsWith(name + "=")) {
+      return decodeURIComponent(c.slice(name.length + 1));
+    }
+  }
+  return undefined;
+}
+
+export { parseCookie }

--- a/apps/server/src/http/index.ts
+++ b/apps/server/src/http/index.ts
@@ -17,6 +17,7 @@ import { pluginBundleRouteHandler } from './plugin-bundle';
 import { pluginsComponentsRouteHandler } from './plugins-components';
 import { publicRouteHandler } from './public';
 import { uploadFileRouteHandler } from './upload';
+import { sessionRouteHandler } from './session'
 import { HttpValidationError } from './utils';
 
 type RouteContext = {
@@ -49,7 +50,8 @@ const routeHandlers: Partial<
   POST: {
     exact: {
       '/upload': (req, res) => uploadFileRouteHandler(req, res),
-      '/login': (req, res) => loginRouteHandler(req, res)
+      '/login': (req, res) => loginRouteHandler(req, res),
+      '/session': (req, res) => sessionRouteHandler(req, res)
     },
     prefix: {}
   }

--- a/apps/server/src/http/login.ts
+++ b/apps/server/src/http/login.ts
@@ -209,8 +209,16 @@ const loginRouteHandler = async (
     expiresIn: '86400s' // 1 day
   });
 
-  res.writeHead(200, { 'Content-Type': 'application/json' });
-  res.end(JSON.stringify({ success: true, token }));
+  const cookie = 
+    `session=${token}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${60 * 60 * 24 * 7}`;
+
+  res.writeHead(200, { 
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Allow-Origin': '*',
+    'Set-Cookie': cookie
+  });
+  res.end(JSON.stringify({ success: true }));
 
   return res;
 };

--- a/apps/server/src/http/session.ts
+++ b/apps/server/src/http/session.ts
@@ -1,0 +1,50 @@
+import { eq, sql } from 'drizzle-orm';
+import http from 'http';
+import { getUserByToken } from '../db/queries/users';
+import { parseCookie } from '../helpers/parse-cookie';
+
+const sessionRouteHandler = async (
+  req: http.IncomingMessage,
+  res: http.ServerResponse
+) => {
+
+    const cookieHeader =
+        (req.headers['cookie'] as string | '') ??
+        (req.headers['Cookie'] as string | '');
+
+    if (!cookieHeader) {
+        res.writeHead(403, {'Content-Type': 'application/json'})
+        res.end(JSON.stringify({ success: false }));
+
+        return res;
+    }
+
+    const sessionToken = parseCookie(cookieHeader, 'session')
+
+    if (!sessionToken) {
+        res.writeHead(403, {'Content-Type': 'application/json'})
+        res.end(JSON.stringify({ success: false }));
+
+        return res;
+    }
+
+    const existingSession = await getUserByToken(sessionToken)
+
+    if (!existingSession?.id) {
+        res.writeHead(403, {'Content-Type': 'application/json'})
+        res.end(JSON.stringify({ success: false }));
+
+        return res;
+    }
+
+
+    res.writeHead(200, {'Content-Type': 'application/json'})
+
+    res.end(JSON.stringify({ success: true }));
+
+    return res;
+
+
+}
+
+export { sessionRouteHandler }

--- a/apps/server/src/utils/wss.ts
+++ b/apps/server/src/utils/wss.ts
@@ -27,6 +27,7 @@ import { getUserRoles } from '../routers/users/get-user-roles';
 import { VoiceRuntime } from '../runtimes/voice';
 import { invariant } from './invariant';
 import { pubsub } from './pubsub';
+import { parseCookie } from '../helpers/parse-cookie';
 import type { Context } from './trpc';
 
 let wss: WebSocketServer | undefined;
@@ -41,7 +42,14 @@ const createContext = async ({
   info,
   req
 }: CreateWSSContextFnOptions): Promise<Context> => {
-  const { token } = info.connectionParams as TConnectionParams;
+
+  let token: string | undefined = undefined
+
+  const cookieHeader =
+  (req.headers['cookie'] as string | undefined) ??
+  (req.headers['Cookie'] as string | undefined);
+
+  token = parseCookie(cookieHeader, 'session')
 
   const decodedUser = await getUserByToken(token);
 


### PR DESCRIPTION
## Summary

Initial implementation of session cookies for a more persistent login experience. It isn't perfect but a solid start.

Closes #
https://github.com/Sharkord/sharkord/issues/47

---

## Additional Context

Further down the road I hope to implement rotating session keys to persist logins if remember me is selected. 
This should be a non-breaking change for existing users. I have tested it on my live instance.
CSRF may be a potential risk to consider with this but is arguably better than cached credentials in local storage.