### PR TITLE
fix(#350): send button greyed out

### DIFF
--- a/apps/client/src/components/channel-view/text/index.tsx
+++ b/apps/client/src/components/channel-view/text/index.tsx
@@ -256,9 +256,7 @@ const TextChannel = memo(({ channelId }: TChannelProps) => {
             variant="ghost"
             className="h-8 w-8"
             onClick={onSendMessage}
-            disabled={
-              uploading || sending || !canSendMessages
-            }
+            disabled={uploading || sending || !canSendMessages}
           >
             <Send className="h-4 w-4" />
           </Button>


### PR DESCRIPTION
## Summary

Closes #350

## Additional Context

The `disabled` prop included the condition `files.length === 0`. Omitting this condition fixed the issue. Sending messages and files by pressing the button is working.