### PR TITLE
feat(#401) Add basic text format tools

### DIFF
--- a/apps/client/src/components/channel-view/text/renderer/index.tsx
+++ b/apps/client/src/components/channel-view/text/renderer/index.tsx
@@ -97,7 +97,7 @@ const MessageRenderer = memo(
           )}
         >
           {messageHtml}
-          {message.editedAt && (
+          {message.editedAt ? (
             <Tooltip
               content={
                 <div className="flex flex-col gap-1">
@@ -118,7 +118,7 @@ const MessageRenderer = memo(
                 (edited)
               </span>
             </Tooltip>
-          )}
+          ) : (<span></span>)}
         </div>
 
         {allMedia.map((media, index) => {

--- a/apps/client/src/components/channel-view/text/renderer/index.tsx
+++ b/apps/client/src/components/channel-view/text/renderer/index.tsx
@@ -118,7 +118,9 @@ const MessageRenderer = memo(
                 (edited)
               </span>
             </Tooltip>
-          ) : (<span></span>)}
+          ) : (
+            <span></span>
+          )}
         </div>
 
         {allMedia.map((media, index) => {

--- a/apps/client/src/components/formatting-toolbar/index.tsx
+++ b/apps/client/src/components/formatting-toolbar/index.tsx
@@ -1,0 +1,85 @@
+import { Button } from '@sharkord/ui';
+import type { Editor } from '@tiptap/core';
+import { Link2, Minus, Quote } from 'lucide-react';
+import { memo } from 'react';
+
+type FormattingToolbarProps = {
+  editor: Editor;
+};
+
+type FormatButtonProps = {
+  onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  title: string;
+  content: React.ReactNode;
+};
+
+const FormatButton = ({ onClick, title, content }: FormatButtonProps) => (
+  <Button
+    variant="ghost"
+    size="sm"
+    className="text-muted-foreground w-10 h-10"
+    onClick={onClick}
+    title={title}
+  >
+    {content}
+  </Button>
+);
+
+const FormattingToolbar = memo(({ editor }: FormattingToolbarProps) => {
+  return (
+    <div
+      className="absolute -translate-y-full rounded
+            border bg-background shadow-xs
+            dark:border-input
+            flex items-center"
+    >
+      <FormatButton
+        onClick={() => editor.chain().focus().toggleBold().run()}
+        title="Bold"
+        content={<strong>B</strong>}
+      />
+      <FormatButton
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+        title="Italic"
+        content={<i>I</i>}
+      />
+      <FormatButton
+        onClick={() => editor.chain().focus().toggleUnderline().run()}
+        title="Underline"
+        content={<u>U</u>}
+      />
+      <FormatButton
+        onClick={() => editor.chain().focus().toggleStrike().run()}
+        title="Strikethrough"
+        content={<s>S</s>}
+      />
+      <FormatButton
+        onClick={() => editor.chain().focus().toggleLink().run()}
+        title="Hyperlink"
+        content={<Link2 />}
+      />
+      <FormatButton
+        onClick={() => editor.chain().focus().toggleCode().run()}
+        title="Code"
+        content={'<>'}
+      />
+      <FormatButton
+        onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+        title="Codeblock"
+        content={'<;>'}
+      />
+      <FormatButton
+        onClick={() => editor.chain().focus().setHorizontalRule().run()}
+        title="Horizontal line"
+        content={<Minus />}
+      />
+      <FormatButton
+        onClick={() => editor.chain().focus().toggleBlockquote().run()}
+        title="Blockquete"
+        content={<Quote />}
+      />
+    </div>
+  );
+});
+
+export { FormattingToolbar };

--- a/apps/client/src/components/formatting-toolbar/index.tsx
+++ b/apps/client/src/components/formatting-toolbar/index.tsx
@@ -79,12 +79,24 @@ const FormattingToolbar = memo(({ editor }: FormattingToolbarProps) => {
         content={<Quote />}
       />
       <FormatButton
-        onClick={() => editor.chain().focus().toggleList('bulletList', 'listItem', false).run()}
+        onClick={() =>
+          editor
+            .chain()
+            .focus()
+            .toggleList('bulletList', 'listItem', false)
+            .run()
+        }
         title="Bullet list"
         content={<List />}
       />
       <FormatButton
-        onClick={() => editor.chain().focus().toggleList('orderedList', 'listItem', false).run()}
+        onClick={() =>
+          editor
+            .chain()
+            .focus()
+            .toggleList('orderedList', 'listItem', false)
+            .run()
+        }
         title="Ordered list"
         content={<ListOrdered />}
       />

--- a/apps/client/src/components/formatting-toolbar/index.tsx
+++ b/apps/client/src/components/formatting-toolbar/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@sharkord/ui';
 import type { Editor } from '@tiptap/core';
-import { Link2, Minus, Quote } from 'lucide-react';
+import { Link2, List, ListOrdered, Minus, Quote } from 'lucide-react';
 import { memo } from 'react';
 
 type FormattingToolbarProps = {
@@ -77,6 +77,16 @@ const FormattingToolbar = memo(({ editor }: FormattingToolbarProps) => {
         onClick={() => editor.chain().focus().toggleBlockquote().run()}
         title="Blockquete"
         content={<Quote />}
+      />
+      <FormatButton
+        onClick={() => editor.chain().focus().toggleList('bulletList', 'listItem', false).run()}
+        title="Bullet list"
+        content={<List />}
+      />
+      <FormatButton
+        onClick={() => editor.chain().focus().toggleList('orderedList', 'listItem', false).run()}
+        title="Ordered list"
+        content={<ListOrdered />}
       />
     </div>
   );

--- a/apps/client/src/components/tiptap-input/index.tsx
+++ b/apps/client/src/components/tiptap-input/index.tsx
@@ -15,6 +15,7 @@ import {
   useRef,
   useState
 } from 'react';
+import { FormattingToolbar } from '../formatting-toolbar';
 import type { TEmojiItem } from './helpers';
 import {
   COMMANDS_STORAGE_KEY,
@@ -135,9 +136,13 @@ const TiptapInput = memo(
               return false;
             }
 
-            event.preventDefault();
-            onSubmit?.();
-            return true;
+            if (event.ctrlKey) {
+              event.preventDefault();
+              onSubmit?.();
+              return true;
+            }
+
+            return false;
           }
 
           if (event.key === 'Escape') {
@@ -237,6 +242,7 @@ const TiptapInput = memo(
               isExpanded ? 'max-h-80' : 'max-h-20'
             } ${disabled ? 'opacity-50 cursor-not-allowed bg-muted' : ''}`}
           />
+          {(isHovering || isFocused) && <FormattingToolbar editor={editor} />}
           {showExpandButton && (isHovering || isFocused) && (
             <Button
               type="button"

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -305,6 +305,22 @@ hr {
   height: 2px;
 }
 
+ul {
+  padding-left: 1.5rem;
+  list-style-type: circle;
+  margin: 0;
+}
+
+ol {
+  padding-left: 1.5rem;
+  list-style-type: decimal;
+  margin: 0;
+}
+
+li {
+  list-style-position: outside;
+}
+
 .msg-content.emoji-only {
   font-size: 2.5rem;
   line-height: 1.2;

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -266,6 +266,44 @@ body {
     text-underline-offset: 2px;
   }
 }
+  
+/* Inline code */
+code {
+  background-color: #2d2d2d;
+  color: #dcdcaa;
+  padding: 0.3em;
+  border-radius: 0.5px;
+  font-family: 'Fira Code', monospace;
+  font-size: 0.9em;
+  border-radius: 0.5em;
+}
+
+/* Code block */
+pre code{
+  display: block;
+  background-color: #2d2d2d;
+  color: #c6a241;
+  padding: 0.5em;
+  border-radius: 0.5em;
+  white-space: pre-wrap;
+  word-wrap: break-word; 
+  font-family: 'Fira Code', monospace;
+  overflow-x: auto;
+  margin: 0.5rem 0;
+}
+
+blockquote {
+  display: block;
+  margin-left: 0.5em;
+  padding-left: 0.5em;
+  border-left: solid 2px #2d2d2d;
+}
+
+hr {
+  border: none;
+  background-color: #2d2d2d;
+  height: 2px;
+}
 
 .msg-content.emoji-only {
   font-size: 2.5rem;

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -303,6 +303,7 @@ hr {
   border: none;
   background-color: #2d2d2d;
   height: 2px;
+  margin: 10px;
 }
 
 ul {
@@ -320,6 +321,66 @@ ol {
 li {
   list-style-position: outside;
 }
+
+h1 {
+  display: block;
+  font-size: 2em;
+  margin-top: 0.67em;
+  margin-bottom: 0.67em;
+  margin-left: 0;
+  margin-right: 0;
+  font-weight: bold;
+}
+
+h2 {
+  display: block;
+  font-size: 1.5em;
+  margin-top: 0.83em;
+  margin-bottom: 0.83em;
+  margin-left: 0;
+  margin-right: 0;
+  font-weight: bold;
+}
+
+h3 {
+  display: block;
+  font-size: 1.17em;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  font-weight: bold;
+}
+
+h4 {
+  display: block;
+  font-size: 1em;
+  margin-top: 1.33em;
+  margin-bottom: 1.33em;
+  margin-left: 0;
+  margin-right: 0;
+  font-weight: bold;
+}
+
+h5 {
+  display: block;
+  font-size: .83em;
+  margin-top: 1.67em;
+  margin-bottom: 1.67em;
+  margin-left: 0;
+  margin-right: 0;
+  font-weight: bold;
+}
+
+h6 {
+  display: block;
+  font-size: .67em;
+  margin-top: 2.33em;
+  margin-bottom: 2.33em;
+  margin-left: 0;
+  margin-right: 0;
+  font-weight: bold;
+} 
 
 .msg-content.emoji-only {
   font-size: 2.5rem;

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -322,66 +322,6 @@ li {
   list-style-position: outside;
 }
 
-h1 {
-  display: block;
-  font-size: 2em;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  font-weight: bold;
-}
-
-h2 {
-  display: block;
-  font-size: 1.5em;
-  margin-top: 0.83em;
-  margin-bottom: 0.83em;
-  margin-left: 0;
-  margin-right: 0;
-  font-weight: bold;
-}
-
-h3 {
-  display: block;
-  font-size: 1.17em;
-  margin-top: 1em;
-  margin-bottom: 1em;
-  margin-left: 0;
-  margin-right: 0;
-  font-weight: bold;
-}
-
-h4 {
-  display: block;
-  font-size: 1em;
-  margin-top: 1.33em;
-  margin-bottom: 1.33em;
-  margin-left: 0;
-  margin-right: 0;
-  font-weight: bold;
-}
-
-h5 {
-  display: block;
-  font-size: .83em;
-  margin-top: 1.67em;
-  margin-bottom: 1.67em;
-  margin-left: 0;
-  margin-right: 0;
-  font-weight: bold;
-}
-
-h6 {
-  display: block;
-  font-size: .67em;
-  margin-top: 2.33em;
-  margin-bottom: 2.33em;
-  margin-left: 0;
-  margin-right: 0;
-  font-weight: bold;
-} 
-
 .msg-content.emoji-only {
   font-size: 2.5rem;
   line-height: 1.2;

--- a/apps/server/src/helpers/sanitize-html.ts
+++ b/apps/server/src/helpers/sanitize-html.ts
@@ -27,6 +27,12 @@ const sanitizeMessageHtml = (html: string): string => {
       'li',
       'ul',
       'ol',
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
       // links
       'a',
       // emoji (span wrapper + img fallback)

--- a/apps/server/src/helpers/sanitize-html.ts
+++ b/apps/server/src/helpers/sanitize-html.ts
@@ -19,6 +19,11 @@ const sanitizeMessageHtml = (html: string): string => {
       'em',
       'code',
       'pre',
+      's',
+      'i',
+      'u',
+      'hr',
+      'blockquote',
       // links
       'a',
       // emoji (span wrapper + img fallback)

--- a/apps/server/src/helpers/sanitize-html.ts
+++ b/apps/server/src/helpers/sanitize-html.ts
@@ -27,12 +27,6 @@ const sanitizeMessageHtml = (html: string): string => {
       'li',
       'ul',
       'ol',
-      'h1',
-      'h2',
-      'h3',
-      'h4',
-      'h5',
-      'h6',
       // links
       'a',
       // emoji (span wrapper + img fallback)

--- a/apps/server/src/helpers/sanitize-html.ts
+++ b/apps/server/src/helpers/sanitize-html.ts
@@ -24,6 +24,9 @@ const sanitizeMessageHtml = (html: string): string => {
       'u',
       'hr',
       'blockquote',
+      'li',
+      'ul',
+      'ol',
       // links
       'a',
       // emoji (span wrapper + img fallback)


### PR DESCRIPTION
## Summary

Closes #401.
Adds basic text formatting tools. Bold, italic, underline, strike, link, code, codeblock, horizontal line and blockquete.

Sharkord text editor already supports basic markdown inputs. Editor changes markdown inputs into HTML tags, but sanitization didn't allow all tags and CSS was missing configurations. These changes allow markdowns also work better.

At the moment hyperlink and underline are identical. Should we change link color to something else?
It might be a good idea to add lists also.

This would also change message sending from enter to ctrl+enter. Linebreak with shift+enter didn't work right with codeblock. This might need more work. Or is it better this way? It is way too easy to send message by pressing only enter but that is only my opinion.

## Additional Context

<img width="568" height="501" alt="kuva" src="https://github.com/user-attachments/assets/a6249c60-e6fc-4dd6-8632-3567bf896a8f" />


