### PR TITLE
fix(388): found and corrected auto-login issue for firefox

### DIFF
--- a/apps/client/src/lib/trpc.ts
+++ b/apps/client/src/lib/trpc.ts
@@ -7,8 +7,7 @@ import {
   LocalStorageKey,
   removeLocalStorageItem,
   removeSessionStorageItem,
-  SessionStorageKey,
-  setLocalStorageItemBool
+  SessionStorageKey
 } from '@/helpers/storage';
 import { type AppRouter, type TConnectionParams } from '@sharkord/shared';
 import { createTRPCProxyClient, createWSClient, wsLink } from '@trpc/client';
@@ -21,11 +20,9 @@ let isCleaningUp = false;
 // Firefox fires WebSocket onClose during page refresh; Chrome does not. When navigating away,
 // we must not clear auto-login localStorage or it will be lost on refresh in Firefox.
 let isNavigatingAway = false;
-if (typeof window !== 'undefined') {
-  window.addEventListener('beforeunload', () => {
-    isNavigatingAway = true;
-  });
-}
+window.addEventListener('beforeunload', () => {
+  isNavigatingAway = true;
+});
 
 const initializeTRPC = (host: string) => {
   const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
@@ -98,10 +95,8 @@ const cleanup = () => {
   // cleanup can be called due to various reasons (manual disconnect, connection error, auto-login failure, etc).
   // so we remove any persisted auto-login token to prevent auto-login loops.
   // skip this when navigating away (refresh/close) - Firefox fires onClose during refresh, Chrome does not
-  if (!isNavigatingAway) {
+  if (!isNavigatingAway)
     removeLocalStorageItem(LocalStorageKey.AUTO_LOGIN_TOKEN);
-    setLocalStorageItemBool(LocalStorageKey.AUTO_LOGIN, false);
-  }
 
   resetServerScreens();
   resetServerState();

--- a/apps/client/src/screens/connect/index.tsx
+++ b/apps/client/src/screens/connect/index.tsx
@@ -170,10 +170,6 @@ const Connect = memo(() => {
             data-testid={TestId.CONNECT_AUTO_LOGIN_SWITCH}
             onClick={() => {
               onChange('autoLogin', !values.autoLogin);
-              setLocalStorageItemBool(
-                LocalStorageKey.AUTO_LOGIN,
-                !values.autoLogin
-              );
             }}
           >
             <Switch checked={values.autoLogin} />


### PR DESCRIPTION
## Summary
Fixed issue causing auto-login to not work on firefox.

It wasn't setting the localstorage key correctly and also firefox was triggering the cleanup function when refreshing while chrome does not. That function erased the auto-login token in localstorage. Now it shouldn't activate when refreshing.

Closes #
#388 