### PR TITLE
feat(466): change own user highlight slightly

### DIFF
--- a/apps/client/src/components/mention-chip/index.tsx
+++ b/apps/client/src/components/mention-chip/index.tsx
@@ -1,5 +1,6 @@
-import { useUserById } from '@/features/server/users/hooks';
+import { useOwnUserId, useUserById } from '@/features/server/users/hooks';
 import { getRenderedUsername } from '@/helpers/get-rendered-username';
+import { cn } from '@/lib/utils';
 import { memo } from 'react';
 import { UserPopover } from '../user-popover';
 
@@ -10,12 +11,21 @@ type TMentionChipProps = {
 
 const MentionChip = memo(({ userId, label: labelProp }: TMentionChipProps) => {
   const user = useUserById(userId);
+  const ownUserId = useOwnUserId();
+  const isOwnMention = ownUserId === userId;
   const label =
     labelProp ?? (user ? getRenderedUsername(user) : 'Deleted User');
 
   return (
     <UserPopover userId={userId}>
-      <span className="mention text-primary bg-primary/10 rounded px-0.5 cursor-pointer hover:bg-primary/20">
+      <span
+        className={cn(
+          'mention rounded px-0.5 cursor-pointer transition-colors',
+          isOwnMention
+            ? 'text-yellow-400 dark:text-yellow-200 bg-primary/10 hover:bg-primary/20 font-medium'
+            : 'text-primary bg-primary/10 hover:bg-primary/20'
+        )}
+      >
         @{label}
       </span>
     </UserPopover>


### PR DESCRIPTION
## Summary
This will highlight your own user slightly differently so it becomes more recognizable. At the moment, a pale yellow.

Closes #466 

## Additional Context

This is a small change, feel free to decline if it goes against style wishes.

<img width="373" height="371" alt="grafik" src="https://github.com/user-attachments/assets/511c800d-fe7e-42a6-b8b6-824485cd588c" />
