### PR TITLE
feat: show notification permission toast when browser permission is blocked

### DIFF
--- a/apps/client/src/features/app/actions.ts
+++ b/apps/client/src/features/app/actions.ts
@@ -104,6 +104,8 @@ export const setBrowserNotifications = async (enabled: boolean) => {
     const permission = await Notification.requestPermission();
 
     if (permission !== 'granted') {
+      toast.error('Notification permission was denied.');
+
       return;
     }
   }


### PR DESCRIPTION
Helium browser blocks notifications on default and there is no feedback if notifications are blocked
<img width="387" height="86" alt="image" src="https://github.com/user-attachments/assets/959b1691-5a92-453e-8c08-4fae85c2169d" />
