### PR TITLE
fix(244): storage size report

### DIFF
--- a/apps/server/src/db/publishers.ts
+++ b/apps/server/src/db/publishers.ts
@@ -174,8 +174,6 @@ const publishChannel = async (
           .map((u) => u.id)
           .filter((id) => !affectedUserIds.includes(id));
 
-        console.log('now private', { lostAccessUserIds });
-
         if (lostAccessUserIds.length > 0) {
           pubsub.publishFor(
             lostAccessUserIds,
@@ -184,8 +182,6 @@ const publishChannel = async (
           );
         }
       } else {
-        console.log('now public', { allUserIds });
-
         // channel is now public, so all users should have access to it
         // send a create event
         // if a user already has the channel in the state it will ignore the create event, so we don't need to worry about that

--- a/apps/server/src/routers/channels/update-channel.ts
+++ b/apps/server/src/routers/channels/update-channel.ts
@@ -48,12 +48,6 @@ const updateChannelRoute = protectedProcedure
     // privacy setting changed
     const ensureUserAccess = updatedChannel.private !== oldChannel?.private;
 
-    console.log('updated channel', {
-      updatedChannel,
-      oldChannel,
-      ensureUserAccess
-    });
-
     publishChannel(updatedChannel.id, 'update', ensureUserAccess);
     enqueueActivityLog({
       type: ActivityLogType.UPDATED_CHANNEL,

--- a/apps/server/src/utils/__tests__/metrics.test.ts
+++ b/apps/server/src/utils/__tests__/metrics.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import path from 'path';
+import { DATA_PATH } from '../../helpers/paths';
+import { getDiskMetrics } from '../metrics';
+
+describe('getDiskMetrics', () => {
+  test('should use only the filesystem containing DATA_PATH', async () => {
+    const normalizedDataPath = path.resolve(DATA_PATH);
+    const dataMount = path.dirname(normalizedDataPath);
+
+    const mockedFsSize = [
+      { mount: '/', size: 1_000, used: 300 },
+      { mount: dataMount, size: 500, used: 120 },
+      { mount: '/mnt/other', size: 10_000, used: 9_000 }
+    ];
+
+    const result = await getDiskMetrics({
+      fsSize: async () => mockedFsSize,
+      getUsedFileQuota: async () => 42,
+      dataPath: normalizedDataPath
+    });
+
+    expect(result.totalSpace).toBe(500);
+    expect(result.usedSpace).toBe(120);
+    expect(result.freeSpace).toBe(380);
+    expect(result.sharkordUsedSpace).toBe(42);
+  });
+
+  test('should fallback to the first filesystem when no mount matches DATA_PATH', async () => {
+    const mockedFsSize = [
+      { mount: '/unrelated-a', size: 700, used: 100 },
+      { mount: '/unrelated-b', size: 900, used: 450 }
+    ];
+
+    const result = await getDiskMetrics({
+      fsSize: async () => mockedFsSize,
+      getUsedFileQuota: async () => 0,
+      dataPath: '/definitely-not-matching'
+    });
+
+    expect(result.totalSpace).toBe(700);
+    expect(result.usedSpace).toBe(100);
+    expect(result.freeSpace).toBe(600);
+  });
+});

--- a/apps/server/src/utils/metrics.ts
+++ b/apps/server/src/utils/metrics.ts
@@ -1,15 +1,67 @@
 import type { TDiskMetrics } from '@sharkord/shared';
+import path from 'path';
 import si from 'systeminformation';
 import { getUsedFileQuota } from '../db/queries/files';
+import { DATA_PATH } from '../helpers/paths';
 
-const getDiskMetrics = async (): Promise<TDiskMetrics> => {
+type TDiskInfo = Awaited<ReturnType<typeof si.fsSize>>[number];
+type TDiskMountInfo = Pick<TDiskInfo, 'mount' | 'size' | 'used'>;
+
+type TGetDiskMetricsDeps = {
+  fsSize?: () => Promise<TDiskMountInfo[]>;
+  getUsedFileQuota?: () => Promise<number>;
+  dataPath?: string;
+};
+
+const normalizeMountPath = (value: string) => {
+  const resolved = path.resolve(value);
+
+  if (resolved === path.sep) {
+    return resolved;
+  }
+
+  return resolved.endsWith(path.sep) ? resolved.slice(0, -1) : resolved;
+};
+
+const getDiskForDataPath = (disks: TDiskMountInfo[], dataPath: string) => {
+  const normalizedDataPath = path.resolve(dataPath);
+
+  const matching = disks.filter((disk) => {
+    if (!disk.mount) {
+      return false;
+    }
+
+    const mountPath = normalizeMountPath(disk.mount);
+
+    return (
+      normalizedDataPath === mountPath ||
+      normalizedDataPath.startsWith(`${mountPath}${path.sep}`)
+    );
+  });
+
+  if (matching.length > 0) {
+    return matching.sort((a, b) => b.mount.length - a.mount.length)[0];
+  }
+
+  return disks[0];
+};
+
+const getDiskMetrics = async (
+  deps: TGetDiskMetricsDeps = {} // these are just used for testing purposes, so we can mock them
+): Promise<TDiskMetrics> => {
+  const fsSize = deps.fsSize ?? (() => si.fsSize());
+  const getFilesUsedSpace = deps.getUsedFileQuota ?? getUsedFileQuota;
+  const dataPath = deps.dataPath ?? DATA_PATH;
+
   const [diskInfo, filesUsedSpace] = await Promise.all([
-    si.fsSize(),
-    getUsedFileQuota()
+    fsSize(),
+    getFilesUsedSpace()
   ]);
 
-  const totalDisk = diskInfo.reduce((acc, disk) => acc + disk.size, 0);
-  const usedDisk = diskInfo.reduce((acc, disk) => acc + disk.used, 0);
+  const selectedDisk = getDiskForDataPath(diskInfo, dataPath);
+
+  const totalDisk = selectedDisk?.size ?? 0;
+  const usedDisk = selectedDisk?.used ?? 0;
 
   const freeDisk = totalDisk - usedDisk;
 


### PR DESCRIPTION
## Summary

Closes #244

## Additional Context

When multiple disks were in the system it would count everything. Now it only counts the disk Sharkord data is in.