### PR TITLE
fix(501): normalize line breaks in chat messages

### DIFF
--- a/apps/client/src/components/channel-view/text/index.tsx
+++ b/apps/client/src/components/channel-view/text/index.tsx
@@ -14,7 +14,7 @@ import {
   ChannelPermission,
   TYPING_MS,
   getTrpcError,
-  linkifyHtml
+  prepareMessageHtml
 } from '@sharkord/shared';
 import { Spinner } from '@sharkord/ui';
 import { throttle } from 'lodash-es';
@@ -93,7 +93,7 @@ const TextChannel = memo(({ channelId }: TChannelProps) => {
 
       try {
         await trpc.messages.send.mutate({
-          content: linkifyHtml(message),
+          content: prepareMessageHtml(message),
           channelId,
           files: files.map((f) => f.id)
         });

--- a/apps/client/src/components/channel-view/text/message-edit-inline.tsx
+++ b/apps/client/src/components/channel-view/text/message-edit-inline.tsx
@@ -1,6 +1,10 @@
 import { TiptapInput } from '@/components/tiptap-input';
 import { getTRPCClient } from '@/lib/trpc';
-import { type TMessage, isEmptyMessage, linkifyHtml } from '@sharkord/shared';
+import {
+  type TMessage,
+  isEmptyMessage,
+  prepareMessageHtml
+} from '@sharkord/shared';
 import { AutoFocus } from '@sharkord/ui';
 import { memo, useCallback, useState } from 'react';
 import { toast } from 'sonner';
@@ -29,7 +33,7 @@ const MessageEditInline = memo(
         try {
           await trpc.messages.edit.mutate({
             messageId: message.id,
-            content: linkifyHtml(newValue)
+            content: prepareMessageHtml(newValue)
           });
 
           toast.success('Message edited');

--- a/apps/client/src/components/channel-view/text/renderer/index.tsx
+++ b/apps/client/src/components/channel-view/text/renderer/index.tsx
@@ -93,7 +93,8 @@ const MessageRenderer = memo(
         <div
           className={cn(
             'prose max-w-full wrap-break-word msg-content',
-            emojiOnly && 'emoji-only'
+            emojiOnly && 'emoji-only',
+            message.editedAt && 'msg-edited'
           )}
         >
           {messageHtml}

--- a/apps/client/src/components/thread-sidebar/thread-compose.tsx
+++ b/apps/client/src/components/thread-sidebar/thread-compose.tsx
@@ -3,7 +3,7 @@ import { playSound } from '@/features/server/sounds/actions';
 import { SoundType } from '@/features/server/types';
 import { getTRPCClient } from '@/lib/trpc';
 import type { TJoinedPublicUser } from '@sharkord/shared';
-import { TYPING_MS, getTrpcError, linkifyHtml } from '@sharkord/shared';
+import { TYPING_MS, getTrpcError, prepareMessageHtml } from '@sharkord/shared';
 import { throttle } from 'lodash-es';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
@@ -43,7 +43,7 @@ const ThreadCompose = memo(
 
         try {
           await trpc.messages.send.mutate({
-            content: linkifyHtml(message),
+            content: prepareMessageHtml(message),
             channelId,
             files: files.map((f) => f.id),
             parentMessageId

--- a/apps/client/src/features/server/hooks.ts
+++ b/apps/client/src/features/server/hooks.ts
@@ -2,7 +2,7 @@ import { getTRPCClient } from '@/lib/trpc';
 import {
   ChannelPermission,
   Permission,
-  linkifyHtml,
+  prepareMessageHtml,
   type TPluginSlotContext
 } from '@sharkord/shared';
 import { useCallback, useMemo, useRef } from 'react';
@@ -139,7 +139,7 @@ export const usePluginComponentContext = (): TPluginSlotContext => {
 
         await trpc.messages.send.mutate({
           channelId,
-          content: linkifyHtml(`<p>${content}</p>`),
+          content: prepareMessageHtml(`<p>${content}</p>`),
           files: []
         });
       }

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -277,8 +277,12 @@ body {
   }
 }
 
-.msg-content > *:nth-last-child(2) {
+.msg-content.msg-edited > *:nth-last-child(2) {
   display: inline;
+}
+
+.msg-content p:empty {
+  min-height: 1em;
 }
 
 .react-tweet-theme {

--- a/apps/server/src/helpers/__tests__/sanitize-html.test.ts
+++ b/apps/server/src/helpers/__tests__/sanitize-html.test.ts
@@ -64,8 +64,11 @@ describe('sanitize-html', () => {
     ).toBe('');
   });
 
-  test('should strip <h1>-<h6> tags but keep content', () => {
-    expect(sanitizeMessageHtml('<h1>heading</h1>')).toBe('heading');
+  test('should convert <h1>-<h6> tags to <p> to preserve block structure', () => {
+    expect(sanitizeMessageHtml('<h1>heading</h1>')).toBe('<p>heading</p>');
+    expect(sanitizeMessageHtml('<h4>heading</h4><p>body</p>')).toBe(
+      '<p>heading</p><p>body</p>'
+    );
   });
 
   test('should strip event handler attributes', () => {

--- a/apps/server/src/helpers/sanitize-html.ts
+++ b/apps/server/src/helpers/sanitize-html.ts
@@ -36,7 +36,20 @@ const sanitizeMessageHtml = (html: string): string => {
     },
     allowedSchemes: ['http', 'https', 'mailto'],
     // disallow any script or event handler attributes globally
-    disallowedTagsMode: 'discard'
+    disallowedTagsMode: 'discard',
+    // headings and list items contain inline content only, so replace with <p>
+    // to preserve their text as a block rather than collapsing it to bare text
+    // block containers (div, blockquote, section etc) may wrap <p> children, so
+    // just discard the wrapper -- the inner <p> tags are already correct structure
+    transformTags: {
+      h1: 'p',
+      h2: 'p',
+      h3: 'p',
+      h4: 'p',
+      h5: 'p',
+      h6: 'p',
+      li: 'p'
+    }
   });
 
   return input;

--- a/packages/shared/src/helpers/__tests__/prepare-message-html.test.ts
+++ b/packages/shared/src/helpers/__tests__/prepare-message-html.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  normalizeLineBreaks,
+  prepareMessageHtml
+} from '../prepare-message-html';
+
+describe('normalizeLineBreaks', () => {
+  test('trailing hard-break before </p><p> becomes an empty paragraph', () => {
+    expect(
+      normalizeLineBreaks(
+        '<p>line one<br class="hard-break"></p><p>line two</p>'
+      )
+    ).toBe('<p>line one</p><p></p><p>line two</p>');
+  });
+
+  test('trailing hard-break inside <h4> before <p> becomes an empty paragraph', () => {
+    expect(
+      normalizeLineBreaks('<h4>heading<br class="hard-break"></h4><p>body</p>')
+    ).toBe('<h4>heading</h4><p></p><p>body</p>');
+  });
+
+  test('trailing hard-break inside <div> before <blockquote> becomes an empty paragraph', () => {
+    expect(
+      normalizeLineBreaks(
+        '<div>text<br class="hard-break"></div><blockquote>quote</blockquote>'
+      )
+    ).toBe('<div>text</div><p></p><blockquote>quote</blockquote>');
+  });
+
+  test('mid-paragraph hard-break is left untouched', () => {
+    const input = '<p>line one<br class="hard-break">line two</p>';
+    expect(normalizeLineBreaks(input)).toBe(input);
+  });
+
+  test('trailing hard-break at end of last paragraph (no following block) is left untouched', () => {
+    const input = '<p>line one<br class="hard-break"></p>';
+    expect(normalizeLineBreaks(input)).toBe(input);
+  });
+
+  test('multiple trailing hard-breaks across paragraphs are all normalised', () => {
+    expect(
+      normalizeLineBreaks(
+        '<p>one<br class="hard-break"></p><p>two<br class="hard-break"></p><p>three</p>'
+      )
+    ).toBe('<p>one</p><p></p><p>two</p><p></p><p>three</p>');
+  });
+
+  test('hard-break with extra whitespace before closing tag still matches', () => {
+    expect(
+      normalizeLineBreaks(
+        '<p>line one<br class="hard-break">  </p><p>line two</p>'
+      )
+    ).toBe('<p>line one</p><p></p><p>line two</p>');
+  });
+
+  test('content with no hard-breaks is returned unchanged', () => {
+    const input = '<p>hello</p><p>world</p>';
+    expect(normalizeLineBreaks(input)).toBe(input);
+  });
+
+  test('empty string is returned unchanged', () => {
+    expect(normalizeLineBreaks('')).toBe('');
+  });
+});
+
+describe('prepareMessageHtml', () => {
+  test('normalizes trailing hard-break and linkifies in a single call', () => {
+    expect(
+      prepareMessageHtml(
+        '<p>see https://example.com<br class="hard-break"></p><p>next</p>'
+      )
+    ).toBe(
+      '<p>see <a href="https://example.com" target="_blank" rel="noopener noreferrer">https://example.com</a></p><p></p><p>next</p>'
+    );
+  });
+
+  test('normalization runs before linkification', () => {
+    // if order were reversed, linkify would wrap text nodes and the br regex
+    // would never match the now-fragmented html
+    const input = '<p>text<br class="hard-break"></p><p>more</p>';
+    const result = prepareMessageHtml(input);
+
+    expect(result).toContain('<p></p>');
+  });
+
+  test('passes through content with neither hard-breaks nor urls unchanged', () => {
+    const input = '<p>hello world</p>';
+    expect(prepareMessageHtml(input)).toBe(input);
+  });
+});

--- a/packages/shared/src/helpers/index.ts
+++ b/packages/shared/src/helpers/index.ts
@@ -5,6 +5,7 @@ export * from './get-random-string';
 export * from './has-mention';
 export * from './linkify-html';
 export * from './message-sanitizer';
+export * from './prepare-message-html';
 export * from './sha256';
 export * from './strip-zalgo';
 export * from './trpc-errors';

--- a/packages/shared/src/helpers/prepare-message-html.ts
+++ b/packages/shared/src/helpers/prepare-message-html.ts
@@ -1,0 +1,21 @@
+import { linkifyHtml } from './linkify-html';
+
+// block tags that can wrap a trailing hard-break before another block begins
+const BLOCK_TAG = '(?:p|h[1-6]|blockquote|li|div|pre)';
+
+// a trailing hard-break before a closing block tag is invisible in static html
+// rendering -- convert it to an empty <p></p> so the line break is preserved
+const normalizeLineBreaks = (html: string): string =>
+  html.replace(
+    new RegExp(
+      `<br\\s[^>]*class="hard-break"[^>]*>\\s*</(${BLOCK_TAG})>(\\s*<${BLOCK_TAG})`,
+      'g'
+    ),
+    '</$1><p></p>$2'
+  );
+
+// applies all pre-send transformations to outgoing message html in the correct order
+const prepareMessageHtml = (html: string): string =>
+  linkifyHtml(normalizeLineBreaks(html));
+
+export { normalizeLineBreaks, prepareMessageHtml };


### PR DESCRIPTION
## Summary

With this change, we normalize empty lines on the way out of the editor, so that they will round-trip and preserve whitespace in the expected way.

Closes #501

## Additional Context

This works around an issue with prosemirror, where they inject `<br class="Prosemirror-trailingBreak" />` at the end of block elements, only while editing, only so you can get your cursor into that place.  That element they inject is not meant to actually add a visual rendered line, but alas, it does in some cases, and so that is what creates the disconnect.  When we render the message outside the editor, nobody is injecting that `br` and so empty lines that were there in the editor appear to be missing now.

Our "least-bad" workaround approach here is to find block elements with trailing `<br class="hard-break">`, with that block element followed by another block element -- and then inject a `<p></p>` between the block elements and delete the `<br>`.  Essentially, we "promote" the empty line at the end of the block to be its own `p` sibling to the previous and next elements.  Additionally, we also make sure to translate "disallowed" block elements into `p` elements, to handle case 1 below.

Also, the `inline` treatment meant for the `(edited)` indication was getting in the way, because for non-edited messages that `nth-last-child` selector was still getting applied and making some block elements to be rendered as inline!

## Reproduction Steps

There are at least two ways to reproduce this bad behavior, both requiring editing copy/pasted rich content in the editor.

1. Copy the rendered "line 1 / line 2" text below
2. In the chat input, place your cursor at the end of the first list item and press `shift`+`enter`
3. Observe there is a blank line between 1 and 2 and press `enter` to send

The rendered message now contains no blank line between 1 and 2.

#### Copy/paste these two lines for each case below in order to reproduce the bug...

Case 1 - (`h4` followed by `p`):
> #### line 1
> line 2

Case 2 -  (`p` followed by `p`)

> line 1
>
> line 2

## Potential Alternatives

This PR seems like it will be net-positive as-is, but it may be worth considering some alternatives.

**Markdown plain text input** - Using a plain `textarea` (or `contenteditable="plaintext-only"`) might just make everyone's life simpler and better.  Web-based WYSIWYG editors are so extremely difficult that for example, even after ten years of smart people trying with all their might, ProseMirror still has bugs like this.  Even when they work as intended, humans have a hard time with them rich-text editors anyway.  In the simpler version, messages could be stored in plain text and interpreted as markdown on the way to be rendered.  This would remove a ton of complexity and computational overhead while editing on low-powered devices.

**No hard breaks** - Right now, pressing `shift`+`enter` is the way to make a newline without sending the message -- but the editor is *also* interpreting that `shift` to mean "make a hard break within this block" rather than "make a new block".  So we might try overriding the keymaps to say that from the editor's point of view, `shift`+`enter` should be treated as `enter`.  This is probably a good idea on its own, but it's a bigger change, and still doesn't fix the variation of this collapsing newline bug where a hard break is part of the rich content that is pasted in and then edited.

## See also

Some discussion in upstream projects:
- https://github.com/ProseMirror/prosemirror/issues/1511
- https://github.com/ueberdosis/tiptap/issues/1500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual indicator to show when a message has been edited.

* **Bug Fixes**
  * Fixed message formatting to properly preserve line breaks and empty paragraphs.
  * Improved HTML processing to maintain headers and list items as content blocks instead of losing them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->