### PR TITLE
fix(239): controls bar overlapping

### DIFF
--- a/apps/client/src/components/channel-view/voice/controls-bar.tsx
+++ b/apps/client/src/components/channel-view/voice/controls-bar.tsx
@@ -39,7 +39,7 @@ const ControlsBar = memo(({ channelId }: TControlsBarProps) => {
   return (
     <div
       className={cn(
-        'absolute bottom-8 left-0 right-0 flex justify-center items-center pointer-events-none z-50',
+        'absolute bottom-8 left-0 right-0 hidden md:flex justify-center items-center pointer-events-none',
         'transition-all duration-300 ease-in-out gap-3',
         isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
       )}


### PR DESCRIPTION
## Summary

Closes #239

## Additional Context

Also hides the bar on smaller screens.