### PR TITLE
feat: add missing i18n translations for UI text

### DIFF
--- a/apps/client/src/components/channel-view/text/message-reactions.tsx
+++ b/apps/client/src/components/channel-view/text/message-reactions.tsx
@@ -24,13 +24,15 @@ type TTooltipPreviewProps = {
 
 const TooltipPreview = memo(
   ({ emojiName, emojiSlot, reacters }: TTooltipPreviewProps) => {
+    const { t } = useTranslation('common');
+
     return (
       <div className="flex items-center gap-2 max-w-xs wrap-break-word whitespace-pre-wrap text-sm">
         <div className="flex items-center flex-col">
           {emojiSlot}
           <span className="text-[8px]">:{emojiName}:</span>
         </div>
-        <span className="text-xs">was reacted by {reacters}.</span>
+        <span className="text-xs">{t('wasReactedBy', { reacters })}</span>
       </div>
     );
   }
@@ -97,6 +99,7 @@ type TReactionProps = {
 
 const Reaction = memo(
   ({ emoji, count, isUserReacted, onClick, file, userIds }: TReactionProps) => {
+    const { t } = useTranslation('common');
     const usernames = useUsernames();
     const tooltipContent = useMemo(() => {
       const names = userIds
@@ -104,11 +107,13 @@ const Reaction = memo(
         .map((userId) => usernames[userId] || 'Unknown');
 
       if (userIds.length > MAX_REACTORS_PREVIEW) {
-        names.push(`and ${userIds.length - MAX_REACTORS_PREVIEW} more`);
+        names.push(
+          t('andMore', { count: userIds.length - MAX_REACTORS_PREVIEW })
+        );
       }
 
       return names.join(', ');
-    }, [userIds, usernames]);
+    }, [userIds, usernames, t]);
 
     return (
       <Tooltip

--- a/apps/client/src/components/channel-view/text/message.tsx
+++ b/apps/client/src/components/channel-view/text/message.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils';
 import { hasMention, Permission, type TJoinedMessage } from '@sharkord/shared';
 import { MessageSquareText } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { MessageActions } from './message-actions';
 import { MessageEditInline } from './message-edit-inline';
 import { MessageRenderer } from './renderer';
@@ -24,6 +25,7 @@ const Message = memo(
     disableFiles,
     disableReactions
   }: TMessageProps) => {
+    const { t } = useTranslation('common');
     const [isEditing, setIsEditing] = useState(false);
     const isFromOwnUser = useIsOwnUser(message.userId);
     const can = useCan();
@@ -72,9 +74,7 @@ const Message = memo(
                 className="flex items-center gap-1 text-xs text-primary/70 hover:text-primary hover:underline mt-1 transition-colors"
               >
                 <MessageSquareText className="h-3 w-3" />
-                <span>
-                  {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
-                </span>
+                <span>{t('reply', { count: replyCount })}</span>
               </button>
             )}
             {!disableActions && (

--- a/apps/client/src/components/dialogs/search/search-result-message.tsx
+++ b/apps/client/src/components/dialogs/search/search-result-message.tsx
@@ -5,6 +5,7 @@ import type { TMessageJumpToTarget } from '@/types';
 import { IconButton, Tooltip } from '@sharkord/ui';
 import { ArrowRight, Hash } from 'lucide-react';
 import { memo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { TSearchResultMessage } from './types';
 
 type TSearchResultMessageCardProps = {
@@ -15,6 +16,8 @@ type TSearchResultMessageCardProps = {
 
 const SearchResultMessageCard = memo(
   ({ message, userName, onJump }: TSearchResultMessageCardProps) => {
+    const { t } = useTranslation('dialogs');
+
     const handleJump = useCallback(() => {
       onJump({
         channelId: message.channelId,
@@ -46,7 +49,7 @@ const SearchResultMessageCard = memo(
               {!!message.parentMessageId && (
                 <>
                   <span>•</span>
-                  <span>In thread</span>
+                  <span>{t('inThread')}</span>
                 </>
               )}
             </div>
@@ -63,8 +66,8 @@ const SearchResultMessageCard = memo(
           <Tooltip
             content={
               message.parentMessageId
-                ? 'Jump to thread original message'
-                : 'Jump to message'
+                ? t('jumpToThreadMessage')
+                : t('jumpToMessage')
             }
           >
             <IconButton

--- a/apps/client/src/components/emoji-picker/custom-emoji-tab.tsx
+++ b/apps/client/src/components/emoji-picker/custom-emoji-tab.tsx
@@ -1,6 +1,7 @@
 import type { TEmojiItem } from '@/components/tiptap-input/helpers';
 import type { EmojiItem } from '@tiptap/extension-emoji';
 import { memo, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { toTEmojiItem } from './emoji-data';
 import { EmojiGrid } from './emoji-grid';
 import { useRecentEmojis } from './use-recent-emojis';
@@ -12,6 +13,7 @@ interface CustomEmojiTabProps {
 
 const CustomEmojiTab = memo(
   ({ customEmojis, onEmojiSelect }: CustomEmojiTabProps) => {
+    const { t } = useTranslation('common');
     const { addRecent } = useRecentEmojis();
 
     const convertedEmojis = useMemo(
@@ -31,10 +33,8 @@ const CustomEmojiTab = memo(
       return (
         <div className="flex flex-col items-center justify-center h-full text-muted-foreground p-4 text-center">
           <span className="text-3xl mb-2">:(</span>
-          <p className="text-sm">No custom emojis available</p>
-          <p className="text-xs mt-1">
-            Server admins can upload custom emojis in server settings
-          </p>
+          <p className="text-sm">{t('noCustomEmojis')}</p>
+          <p className="text-xs mt-1">{t('serverAdminsCanUpload')}</p>
         </div>
       );
     }
@@ -42,7 +42,7 @@ const CustomEmojiTab = memo(
     return (
       <div className="flex flex-col h-full">
         <div className="px-3 py-2 text-xs font-medium text-muted-foreground">
-          Server emojis ({convertedEmojis.length})
+          {t('serverEmojis', { count: convertedEmojis.length })}
         </div>
 
         <div className="flex-1 min-h-0">

--- a/apps/client/src/components/emoji-picker/index.tsx
+++ b/apps/client/src/components/emoji-picker/index.tsx
@@ -11,6 +11,7 @@ import {
   TabsTrigger
 } from '@sharkord/ui';
 import { memo, useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { CustomEmojiTab } from './custom-emoji-tab';
 import { ALL_EMOJIS, searchEmojis, toTEmojiItem } from './emoji-data';
 import { EmojiGrid } from './emoji-grid';
@@ -25,6 +26,7 @@ type TEmojiPickerProps = {
 
 const EmojiPicker = memo(
   ({ children, onEmojiSelect, defaultTab = 'native' }: TEmojiPickerProps) => {
+    const { t } = useTranslation('common');
     const [open, setOpen] = useState(false);
     const [search, setSearch] = useState('');
     const customEmojis = useCustomEmojis();
@@ -88,7 +90,7 @@ const EmojiPicker = memo(
           <div className="h-full flex flex-col">
             <div className="p-3 border-b">
               <Input
-                placeholder="Search all emojis..."
+                placeholder={t('searchAllEmojis')}
                 value={search}
                 onChange={handleSearchChange}
                 className="h-9"
@@ -99,7 +101,7 @@ const EmojiPicker = memo(
             {isSearching ? (
               <div className="flex flex-col flex-1 min-h-0">
                 <div className="px-3 py-2 text-xs font-medium text-muted-foreground">
-                  Search results ({searchResults.length})
+                  {t('searchResults', { count: searchResults.length })}
                 </div>
                 <div className="flex-1 min-h-0">
                   <EmojiGrid
@@ -115,8 +117,8 @@ const EmojiPicker = memo(
                 className="flex-1 flex flex-col min-h-0"
               >
                 <TabsList className="grid w-full grid-cols-2 rounded-none border-b">
-                  <TabsTrigger value="native">Emoji</TabsTrigger>
-                  <TabsTrigger value="custom">Custom</TabsTrigger>
+                  <TabsTrigger value="native">{t('emojiTab')}</TabsTrigger>
+                  <TabsTrigger value="custom">{t('customTab')}</TabsTrigger>
                 </TabsList>
                 <TabsContent value="native" className="flex-1 mt-0 min-h-0">
                   <NativeEmojiTab onEmojiSelect={handleEmojiSelect} />

--- a/apps/client/src/components/permissions-list/index.tsx
+++ b/apps/client/src/components/permissions-list/index.tsx
@@ -2,6 +2,7 @@ import { cn } from '@/lib/utils';
 import { Permission, permissionLabels } from '@sharkord/shared';
 import { Badge } from '@sharkord/ui';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 type PermissionsListProps = {
   permissions: Permission[];
@@ -21,6 +22,8 @@ const PermissionsList = memo(
     className = '',
     maxDisplay
   }: PermissionsListProps) => {
+    const { t } = useTranslation('common');
+
     if (!permissions.length) {
       return (
         <div
@@ -32,7 +35,7 @@ const PermissionsList = memo(
             className
           )}
         >
-          <span>No permissions</span>
+          <span>{t('noPermissions')}</span>
         </div>
       );
     }

--- a/apps/client/src/components/thread-sidebar/index.tsx
+++ b/apps/client/src/components/thread-sidebar/index.tsx
@@ -2,6 +2,7 @@ import { ResizableSidebar } from '@/components/resizable-sidebar';
 import { useThreadSidebar } from '@/features/app/hooks';
 import { LocalStorageKey } from '@/helpers/storage';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ThreadContent } from './tread-content';
 
 const MIN_WIDTH = 360;
@@ -9,12 +10,13 @@ const MAX_WIDTH = 600;
 const DEFAULT_WIDTH = 384;
 
 const ThreadContentWrapper = memo(() => {
+  const { t } = useTranslation('common');
   const { parentMessageId, channelId } = useThreadSidebar();
 
   if (!parentMessageId || !channelId) {
     return (
       <div className="flex-1 flex items-center justify-center">
-        <span className="text-muted-foreground">No thread selected</span>
+        <span className="text-muted-foreground">{t('noThreadSelected')}</span>
       </div>
     );
   }

--- a/apps/client/src/components/thread-sidebar/thread-header.tsx
+++ b/apps/client/src/components/thread-sidebar/thread-header.tsx
@@ -2,13 +2,16 @@ import { closeThreadSidebar } from '@/features/app/actions';
 import { IconButton } from '@sharkord/ui';
 import { MessageSquareText, X } from 'lucide-react';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 const ThreadHeader = memo(() => {
+  const { t } = useTranslation('common');
+
   return (
     <div className="flex items-center justify-between px-4 h-12 border-b border-border shrink-0">
       <div className="flex items-center gap-2">
         <MessageSquareText className="h-4 w-4 text-muted-foreground" />
-        <span className="font-semibold text-sm">Thread</span>
+        <span className="font-semibold text-sm">{t('thread')}</span>
       </div>
       <IconButton
         onClick={closeThreadSidebar}

--- a/apps/client/src/components/thread-sidebar/tread-content.tsx
+++ b/apps/client/src/components/thread-sidebar/tread-content.tsx
@@ -3,6 +3,7 @@ import { useThreadMessages } from '@/features/server/messages/hooks';
 import { Spinner } from '@sharkord/ui';
 import { MessageSquareText } from 'lucide-react';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useScrollController } from '../channel-view/text/hooks/use-scroll-controller';
 import { MessagesGroup } from '../channel-view/text/messages-group';
 import { ParentMessagePreview } from './parent-message-preview';
@@ -16,6 +17,7 @@ type TThreadContentProps = {
 
 const ThreadContent = memo(
   ({ parentMessageId, channelId }: TThreadContentProps) => {
+    const { t } = useTranslation('common');
     const { messages, hasMore, loadMore, loading, fetching, groupedMessages } =
       useThreadMessages(parentMessageId);
 
@@ -55,8 +57,8 @@ const ThreadContent = memo(
                 {messages.length === 0 && !fetching ? (
                   <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-sm">
                     <MessageSquareText className="h-8 w-8 mb-2 opacity-50" />
-                    <p>No replies yet</p>
-                    <p className="text-xs">Be the first to reply</p>
+                    <p>{t('noRepliesYet')}</p>
+                    <p className="text-xs">{t('beFirstToReply')}</p>
                   </div>
                 ) : (
                   <div className="space-y-4">

--- a/apps/client/src/i18n/locales/en/common.json
+++ b/apps/client/src/i18n/locales/en/common.json
@@ -49,5 +49,21 @@
   "deleteFileMsg": "Are you sure you want to delete this file?",
   "fileDeleted": "File deleted",
   "failedDeleteFile": "Failed to delete file",
-  "edited": "(edited)"
+  "edited": "(edited)",
+  "reply_one": "{{count}} reply",
+  "reply_other": "{{count}} replies",
+  "thread": "Thread",
+  "noThreadSelected": "No thread selected",
+  "noRepliesYet": "No replies yet",
+  "beFirstToReply": "Be the first to reply",
+  "noCustomEmojis": "No custom emojis available",
+  "serverAdminsCanUpload": "Server admins can upload custom emojis in server settings",
+  "serverEmojis": "Server emojis ({{count}})",
+  "noPermissions": "No permissions",
+  "searchAllEmojis": "Search all emojis...",
+  "emojiTab": "Emoji",
+  "customTab": "Custom",
+  "searchResults": "Search results ({{count}})",
+  "wasReactedBy": "was reacted by {{reacters}}.",
+  "andMore": "and {{count}} more"
 }

--- a/apps/client/src/i18n/locales/en/dialogs.json
+++ b/apps/client/src/i18n/locales/en/dialogs.json
@@ -97,5 +97,8 @@
   "argument_other": "{{count}} arguments",
   "serverPasswordTitle": "Enter the password",
   "serverPasswordDesc": "This server is password protected. Please enter the password to join.",
-  "joinBtn": "Join"
+  "joinBtn": "Join",
+  "inThread": "In thread",
+  "jumpToThreadMessage": "Jump to thread original message",
+  "jumpToMessage": "Jump to message"
 }

--- a/apps/client/src/i18n/locales/zh/common.json
+++ b/apps/client/src/i18n/locales/zh/common.json
@@ -49,5 +49,21 @@
   "deleteFileMsg": "您确定要删除此文件吗？",
   "fileDeleted": "文件已删除",
   "failedDeleteFile": "删除文件失败",
-  "edited": "（已编辑）"
+  "edited": "（已编辑）",
+  "reply_one": "{{count}} 条回复",
+  "reply_other": "{{count}} 条回复",
+  "thread": "话题",
+  "noThreadSelected": "未选择话题",
+  "noRepliesYet": "暂无回复",
+  "beFirstToReply": "成为第一个回复的人",
+  "noCustomEmojis": "暂无自定义表情",
+  "serverAdminsCanUpload": "服务器管理员可以在服务器设置中上传自定义表情",
+  "serverEmojis": "服务器表情（{{count}}）",
+  "noPermissions": "无权限",
+  "searchAllEmojis": "搜索所有表情...",
+  "emojiTab": "表情",
+  "customTab": "自定义",
+  "searchResults": "搜索结果（{{count}}）",
+  "wasReactedBy": "{{reacters}} 做出了反应。",
+  "andMore": "以及其他 {{count}} 人"
 }

--- a/apps/client/src/i18n/locales/zh/dialogs.json
+++ b/apps/client/src/i18n/locales/zh/dialogs.json
@@ -97,5 +97,8 @@
   "argument_other": "{{count}} 个参数",
   "serverPasswordTitle": "请输入密码",
   "serverPasswordDesc": "此服务器已设置密码保护，请输入密码以加入。",
-  "joinBtn": "加入"
+  "joinBtn": "加入",
+  "inThread": "在话题中",
+  "jumpToThreadMessage": "跳转到话题原始消息",
+  "jumpToMessage": "跳转到消息"
 }


### PR DESCRIPTION
Follow-up to #543 to add missing i18n translations for hardcoded English text throughout the UI
