### PR TITLE
ci: add GHCR workflow for automated Docker image publishing

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -17,6 +17,7 @@ name: Publish Docker Images to GHCR
 #     - ghcr.io/<owner>/<repo>:1 (major only)
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - development


### PR DESCRIPTION
## Summary
Adds automated Docker image publishing to GHCR for easy testing and deployment.

- **Staging images** (`staging`, `staging-<sha>`): Built on push to `development` - convenient for testing the latest changes
- **Release images** (`latest`, `v1.2.3`, `1.2.3`, `1.2`, `1`): Built on tag/release - semantic versioning support
- Multi-arch support (amd64, arm64)
- Docker layer caching for faster builds
- Smart path filtering to skip unnecessary builds (docs, config files)

## Notes
- Public repositories have no GitHub Actions quota limits
- @diogomartino If you decide to merge this, could you please manually run the workflow once from the Actions tab, and then set the package visibility to public in Settings → Packages? Thanks!
