### PR TITLE
feat(566): add customizable date and time format settings

### DIFF
--- a/apps/client/src/components/channel-view/text/messages-group.tsx
+++ b/apps/client/src/components/channel-view/text/messages-group.tsx
@@ -7,7 +7,6 @@ import {
   DELETED_USER_IDENTITY_AND_NAME,
   type TJoinedMessage
 } from '@sharkord/shared';
-import { format } from 'date-fns';
 import { memo } from 'react';
 import { Message } from './message';
 
@@ -47,11 +46,8 @@ const MessagesGroup = memo(
               {getRenderedUsername(user)}
             </span>
             <RelativeTime date={date}>
-              {(relativeTime) => (
-                <span
-                  className="text-primary/60 text-xs"
-                  title={format(date, 'PPpp')}
-                >
+              {(relativeTime, hoverProps) => (
+                <span className="text-primary/60 text-xs" {...hoverProps}>
                   {relativeTime}
                 </span>
               )}

--- a/apps/client/src/components/channel-view/text/pinned-messages-popover.tsx
+++ b/apps/client/src/components/channel-view/text/pinned-messages-popover.tsx
@@ -11,7 +11,6 @@ import {
   Spinner,
   Tooltip
 } from '@sharkord/ui';
-import { format } from 'date-fns';
 import { ArrowRight, Pin } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -42,11 +41,8 @@ const PinnedMessageGroupWrapper = memo(
           <div className="flex items-center gap-2">
             {pinnedDate ? (
               <RelativeTime date={pinnedDate}>
-                {(relativeTime) => (
-                  <span
-                    className="text-xs text-muted-foreground"
-                    title={format(pinnedDate, 'PPpp')}
-                  >
+                {(relativeTime, hoverProps) => (
+                  <span className="text-xs text-muted-foreground" {...hoverProps}>
                     {relativeTime}
                   </span>
                 )}

--- a/apps/client/src/components/channel-view/text/pinned-messages-popover.tsx
+++ b/apps/client/src/components/channel-view/text/pinned-messages-popover.tsx
@@ -42,7 +42,10 @@ const PinnedMessageGroupWrapper = memo(
             {pinnedDate ? (
               <RelativeTime date={pinnedDate}>
                 {(relativeTime, hoverProps) => (
-                  <span className="text-xs text-muted-foreground" {...hoverProps}>
+                  <span
+                    className="text-xs text-muted-foreground"
+                    {...hoverProps}
+                  >
                     {relativeTime}
                   </span>
                 )}

--- a/apps/client/src/components/channel-view/text/renderer/index.tsx
+++ b/apps/client/src/components/channel-view/text/renderer/index.tsx
@@ -107,16 +107,16 @@ const MessageRenderer = memo(
             <Tooltip
               content={
                 <div className="flex flex-col gap-1">
-                  <RelativeTime date={new Date(message.editedAt)}>
-                    {(relativeTime) => (
-                      <span className="text-secondary text-xs">
-                        {editedByUser
-                          ? getRenderedUsername(editedByUser)
-                          : t('unknownUser')}{' '}
-                        {relativeTime}
-                      </span>
-                    )}
-                  </RelativeTime>
+                  <span className="text-secondary text-xs">
+                    {editedByUser
+                      ? getRenderedUsername(editedByUser)
+                      : t('unknownUser')}{' '}
+                    <RelativeTime date={new Date(message.editedAt)}>
+                      {(relativeTime, hoverProps) => (
+                        <span {...hoverProps}>{relativeTime}</span>
+                      )}
+                    </RelativeTime>
+                  </span>
                 </div>
               }
             >

--- a/apps/client/src/components/dialogs/search/search-result-file.tsx
+++ b/apps/client/src/components/dialogs/search/search-result-file.tsx
@@ -44,7 +44,9 @@ const SearchResultFileCard = memo(
             <span className="truncate wrap-anywhere">{result.channelName}</span>
           </span>
           <RelativeTime date={new Date(result.messageCreatedAt)}>
-            {(relativeTime) => <span>{relativeTime}</span>}
+            {(relativeTime, hoverProps) => (
+              <span {...hoverProps}>{relativeTime}</span>
+            )}
           </RelativeTime>
         </div>
 

--- a/apps/client/src/components/dialogs/search/search-result-message.tsx
+++ b/apps/client/src/components/dialogs/search/search-result-message.tsx
@@ -34,7 +34,9 @@ const SearchResultMessageCard = memo(
               </span>
               <span>•</span>
               <RelativeTime date={new Date(message.createdAt)}>
-                {(relativeTime) => <span>{relativeTime}</span>}
+                {(relativeTime, hoverProps) => (
+                  <span {...hoverProps}>{relativeTime}</span>
+                )}
               </RelativeTime>
               <span>•</span>
               <span className="inline-flex min-w-0 max-w-full items-center gap-1">

--- a/apps/client/src/components/relative-time/index.tsx
+++ b/apps/client/src/components/relative-time/index.tsx
@@ -8,7 +8,7 @@ import {
   subHours,
   type Locale
 } from 'date-fns';
-import { memo, type ReactNode, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useState, type ReactNode } from 'react';
 
 const ONE_MINUTE = 60_000;
 const ONE_HOUR = 60 * ONE_MINUTE;
@@ -64,50 +64,57 @@ const getUpdateInterval = (date: Date): number | null => {
   return ONE_HOUR;
 };
 
-const RelativeTime = memo(({ date, interval, children }: TRelativeTimeProps) => {
-  const dateLocale = useDateLocale();
-  const { dateTimeFormat, preferAbsoluteTime } = useDateFormat();
-  const parsedDate = useMemo(
-    () => (typeof date === 'string' ? new Date(date) : date),
-    [date]
-  );
+const RelativeTime = memo(
+  ({ date, interval, children }: TRelativeTimeProps) => {
+    const dateLocale = useDateLocale();
+    const { dateTimeFormat, preferAbsoluteTime } = useDateFormat();
+    const parsedDate = useMemo(
+      () => (typeof date === 'string' ? new Date(date) : date),
+      [date]
+    );
 
-  const [, setCounter] = useState(0);
-  const [isHovered, setIsHovered] = useState(false);
+    const [, setCounter] = useState(0);
+    const [isHovered, setIsHovered] = useState(false);
 
-  useEffect(() => {
-    const updateInterval = interval ?? getUpdateInterval(parsedDate);
+    useEffect(() => {
+      const updateInterval = interval ?? getUpdateInterval(parsedDate);
 
-    // if no update interval is needed, don't set up a timer
-    if (updateInterval === null) {
-      return;
-    }
+      // if no update interval is needed, don't set up a timer
+      if (updateInterval === null) {
+        return;
+      }
 
-    const timer = setInterval(() => {
-      // force re-render to update the relative time display
-      setCounter((prev) => prev + 1);
-    }, updateInterval);
+      const timer = setInterval(() => {
+        // force re-render to update the relative time display
+        setCounter((prev) => prev + 1);
+      }, updateInterval);
 
-    return () => clearInterval(timer);
-  }, [interval, parsedDate]);
+      return () => clearInterval(timer);
+    }, [interval, parsedDate]);
 
-  const shouldShowAbsolute = preferAbsoluteTime || isHovered;
-  const displayTime = useMemo(
-    () =>
-      getFormattedTime(parsedDate, dateLocale, dateTimeFormat, shouldShowAbsolute),
-    [parsedDate, dateLocale, dateTimeFormat, shouldShowAbsolute]
-  );
+    const shouldShowAbsolute = preferAbsoluteTime || isHovered;
+    const displayTime = useMemo(
+      () =>
+        getFormattedTime(
+          parsedDate,
+          dateLocale,
+          dateTimeFormat,
+          shouldShowAbsolute
+        ),
+      [parsedDate, dateLocale, dateTimeFormat, shouldShowAbsolute]
+    );
 
-  const hoverProps: THoverProps = useMemo(
-    () => ({
-      onMouseEnter: () => setIsHovered(true),
-      onMouseLeave: () => setIsHovered(false)
-    }),
-    []
-  );
+    const hoverProps: THoverProps = useMemo(
+      () => ({
+        onMouseEnter: () => setIsHovered(true),
+        onMouseLeave: () => setIsHovered(false)
+      }),
+      []
+    );
 
-  return children(displayTime, hoverProps);
-});
+    return children(displayTime, hoverProps);
+  }
+);
 
 RelativeTime.displayName = 'RelativeTime';
 

--- a/apps/client/src/components/relative-time/index.tsx
+++ b/apps/client/src/components/relative-time/index.tsx
@@ -1,3 +1,4 @@
+import { useDateFormat } from '@/hooks/use-date-format';
 import { useDateLocale } from '@/hooks/use-date-locale';
 import {
   format,
@@ -7,19 +8,33 @@ import {
   subHours,
   type Locale
 } from 'date-fns';
-import { memo, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { memo, type ReactNode, useEffect, useMemo, useState } from 'react';
 
 const ONE_MINUTE = 60_000;
 const ONE_HOUR = 60 * ONE_MINUTE;
-const DEFAULT_FORMAT = 'PPpp'; // eg: 12 August 2022, 14:30
+
+type THoverProps = {
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+};
 
 type TRelativeTimeProps = {
   date: Date | string;
   interval?: number;
-  children: (relativeTime: string) => ReactNode;
+  children: (relativeTime: string, hoverProps: THoverProps) => ReactNode;
 };
 
-const getFormattedTime = (d: Date, dateLocale: Locale): string => {
+const getFormattedTime = (
+  d: Date,
+  dateLocale: Locale,
+  dateTimeFormat: string,
+  preferAbsoluteTime: boolean
+): string => {
+  // If user prefers absolute time, always show absolute format
+  if (preferAbsoluteTime) {
+    return format(d, dateTimeFormat, { locale: dateLocale });
+  }
+
   const now = new Date();
   const twentyFourHoursAgo = subHours(now, 24);
 
@@ -28,7 +43,7 @@ const getFormattedTime = (d: Date, dateLocale: Locale): string => {
     return formatDistanceToNow(d, { addSuffix: true, locale: dateLocale });
   }
 
-  return format(d, DEFAULT_FORMAT, { locale: dateLocale });
+  return format(d, dateTimeFormat, { locale: dateLocale });
 };
 
 const getUpdateInterval = (date: Date): number | null => {
@@ -49,38 +64,51 @@ const getUpdateInterval = (date: Date): number | null => {
   return ONE_HOUR;
 };
 
-const RelativeTime = memo(
-  ({
-    date,
-    interval, // optional override
-    children
-  }: TRelativeTimeProps) => {
-    const dateLocale = useDateLocale();
-    const parsedDate = useMemo(
-      () => (typeof date === 'string' ? new Date(date) : date),
-      [date]
-    );
+const RelativeTime = memo(({ date, interval, children }: TRelativeTimeProps) => {
+  const dateLocale = useDateLocale();
+  const { dateTimeFormat, preferAbsoluteTime } = useDateFormat();
+  const parsedDate = useMemo(
+    () => (typeof date === 'string' ? new Date(date) : date),
+    [date]
+  );
 
-    const [, setCounter] = useState(0);
+  const [, setCounter] = useState(0);
+  const [isHovered, setIsHovered] = useState(false);
 
-    useEffect(() => {
-      const updateInterval = interval ?? getUpdateInterval(parsedDate);
+  useEffect(() => {
+    const updateInterval = interval ?? getUpdateInterval(parsedDate);
 
-      // if no update interval is needed, don't set up a timer
-      if (updateInterval === null) {
-        return;
-      }
+    // if no update interval is needed, don't set up a timer
+    if (updateInterval === null) {
+      return;
+    }
 
-      const timer = setInterval(() => {
-        // force re-render to update the relative time display
-        setCounter((prev) => prev + 1);
-      }, updateInterval);
+    const timer = setInterval(() => {
+      // force re-render to update the relative time display
+      setCounter((prev) => prev + 1);
+    }, updateInterval);
 
-      return () => clearInterval(timer);
-    }, [interval, parsedDate]);
+    return () => clearInterval(timer);
+  }, [interval, parsedDate]);
 
-    return children(getFormattedTime(parsedDate, dateLocale));
-  }
-);
+  const shouldShowAbsolute = preferAbsoluteTime || isHovered;
+  const displayTime = useMemo(
+    () =>
+      getFormattedTime(parsedDate, dateLocale, dateTimeFormat, shouldShowAbsolute),
+    [parsedDate, dateLocale, dateTimeFormat, shouldShowAbsolute]
+  );
+
+  const hoverProps: THoverProps = useMemo(
+    () => ({
+      onMouseEnter: () => setIsHovered(true),
+      onMouseLeave: () => setIsHovered(false)
+    }),
+    []
+  );
+
+  return children(displayTime, hoverProps);
+});
+
+RelativeTime.displayName = 'RelativeTime';
 
 export { RelativeTime };

--- a/apps/client/src/components/server-screens/user-settings/index.tsx
+++ b/apps/client/src/components/server-screens/user-settings/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import type { TServerScreenBaseProps } from '../screens';
 import { ServerScreenLayout } from '../server-screen-layout';
 import { Devices } from './devices';
+import { Interface } from './interface';
 import { Notifications } from './notifications';
 import { Others } from './others';
 import { Password } from './password';
@@ -25,6 +26,7 @@ const UserSettings = memo(({ close }: TUserSettingsProps) => {
             <TabsTrigger value="notifications">
               {t('notificationsTab')}
             </TabsTrigger>
+            <TabsTrigger value="interface">{t('interfaceTab')}</TabsTrigger>
             <TabsTrigger value="others">{t('othersTab')}</TabsTrigger>
           </TabsList>
 
@@ -39,6 +41,9 @@ const UserSettings = memo(({ close }: TUserSettingsProps) => {
           </TabsContent>
           <TabsContent value="notifications" className="space-y-6">
             <Notifications />
+          </TabsContent>
+          <TabsContent value="interface" className="space-y-6">
+            <Interface />
           </TabsContent>
           <TabsContent value="others" className="space-y-6">
             <Others />

--- a/apps/client/src/components/server-screens/user-settings/interface/index.tsx
+++ b/apps/client/src/components/server-screens/user-settings/interface/index.tsx
@@ -1,0 +1,35 @@
+import { LanguageSwitcher } from '@/components/language-switcher';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Group
+} from '@sharkord/ui';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { DateFormatSettings } from '../others/date-format-settings';
+
+const Interface = memo(() => {
+  const { t } = useTranslation('settings');
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('interfaceTitle')}</CardTitle>
+        <CardDescription>{t('interfaceDesc')}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Group label={t('languageLabel')} description={t('languageDesc')}>
+          <LanguageSwitcher />
+        </Group>
+        <DateFormatSettings />
+      </CardContent>
+    </Card>
+  );
+});
+
+Interface.displayName = 'Interface';
+
+export { Interface };

--- a/apps/client/src/components/server-screens/user-settings/others/date-format-settings.tsx
+++ b/apps/client/src/components/server-screens/user-settings/others/date-format-settings.tsx
@@ -1,0 +1,117 @@
+import { useDateFormat } from '@/hooks/use-date-format';
+import { useDateLocale } from '@/hooks/use-date-locale';
+import { Group, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Switch } from '@sharkord/ui';
+import type { Locale } from 'date-fns';
+import { format } from 'date-fns';
+import { memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const DATE_FORMAT_VALUES = [
+  { value: 'PP' },
+  { value: 'PPP' },
+  { value: 'P' },
+  { value: 'yyyy-MM-dd' }
+] as const;
+
+const TIME_FORMAT_VALUES = [
+  { value: 'p' },
+  { value: 'pp' },
+  { value: 'HH:mm' },
+  { value: 'HH:mm:ss' }
+] as const;
+
+const generatePresetLabels = (
+  presets: readonly { value: string }[],
+  previewDate: Date,
+  locale: Locale
+) => {
+  return presets.map((preset) => {
+    try {
+      return { ...preset, label: format(previewDate, preset.value, { locale }) };
+    } catch {
+      return { ...preset, label: preset.value };
+    }
+  });
+};
+
+type FormatSelectorProps = {
+  label: string;
+  description: string;
+  presets: readonly { value: string; label: string }[];
+  currentFormat: string;
+  onFormatChange: (format: string) => void;
+};
+
+const FormatSelector = memo(
+  ({ label, description, presets, currentFormat, onFormatChange }: FormatSelectorProps) => (
+    <Group label={label} description={description}>
+      <Select value={currentFormat} onValueChange={onFormatChange}>
+        <SelectTrigger className="min-w-40">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {presets.map((preset) => (
+            <SelectItem key={preset.value} value={preset.value}>
+              {preset.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </Group>
+  )
+);
+
+FormatSelector.displayName = 'FormatSelector';
+
+const DateFormatSettings = memo(() => {
+  const { t } = useTranslation('settings');
+  const { dateFormat, timeFormat, preferAbsoluteTime, setDateFormat, setTimeFormat, setPreferAbsoluteTime } = useDateFormat();
+  const dateLocale = useDateLocale();
+
+  const previewDate = useMemo(() => new Date(2024, 7, 12, 14, 30, 0), []);
+
+  const dateFormatPresets = useMemo(
+    () => generatePresetLabels(DATE_FORMAT_VALUES, previewDate, dateLocale),
+    [previewDate, dateLocale]
+  );
+
+  const timeFormatPresets = useMemo(
+    () => generatePresetLabels(TIME_FORMAT_VALUES, previewDate, dateLocale),
+    [previewDate, dateLocale]
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-4">
+        <FormatSelector
+          label={t('dateFormatLabel')}
+          description={t('dateFormatDesc')}
+          presets={dateFormatPresets}
+          currentFormat={dateFormat}
+          onFormatChange={setDateFormat}
+        />
+        <FormatSelector
+          label={t('timeFormatLabel')}
+          description={t('timeFormatDesc')}
+          presets={timeFormatPresets}
+          currentFormat={timeFormat}
+          onFormatChange={setTimeFormat}
+        />
+      </div>
+
+      <Group
+        label={t('preferAbsoluteTimeLabel')}
+        description={t('preferAbsoluteTimeDesc')}
+      >
+        <Switch
+          checked={preferAbsoluteTime}
+          onCheckedChange={setPreferAbsoluteTime}
+        />
+      </Group>
+    </div>
+  );
+});
+
+DateFormatSettings.displayName = 'DateFormatSettings';
+
+export { DateFormatSettings };

--- a/apps/client/src/components/server-screens/user-settings/others/date-format-settings.tsx
+++ b/apps/client/src/components/server-screens/user-settings/others/date-format-settings.tsx
@@ -1,6 +1,14 @@
 import { useDateFormat } from '@/hooks/use-date-format';
 import { useDateLocale } from '@/hooks/use-date-locale';
-import { Group, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Switch } from '@sharkord/ui';
+import {
+  Group,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch
+} from '@sharkord/ui';
 import type { Locale } from 'date-fns';
 import { format } from 'date-fns';
 import { memo, useMemo } from 'react';
@@ -27,7 +35,10 @@ const generatePresetLabels = (
 ) => {
   return presets.map((preset) => {
     try {
-      return { ...preset, label: format(previewDate, preset.value, { locale }) };
+      return {
+        ...preset,
+        label: format(previewDate, preset.value, { locale })
+      };
     } catch {
       return { ...preset, label: preset.value };
     }
@@ -43,7 +54,13 @@ type FormatSelectorProps = {
 };
 
 const FormatSelector = memo(
-  ({ label, description, presets, currentFormat, onFormatChange }: FormatSelectorProps) => (
+  ({
+    label,
+    description,
+    presets,
+    currentFormat,
+    onFormatChange
+  }: FormatSelectorProps) => (
     <Group label={label} description={description}>
       <Select value={currentFormat} onValueChange={onFormatChange}>
         <SelectTrigger className="min-w-40">
@@ -65,7 +82,14 @@ FormatSelector.displayName = 'FormatSelector';
 
 const DateFormatSettings = memo(() => {
   const { t } = useTranslation('settings');
-  const { dateFormat, timeFormat, preferAbsoluteTime, setDateFormat, setTimeFormat, setPreferAbsoluteTime } = useDateFormat();
+  const {
+    dateFormat,
+    timeFormat,
+    preferAbsoluteTime,
+    setDateFormat,
+    setTimeFormat,
+    setPreferAbsoluteTime
+  } = useDateFormat();
   const dateLocale = useDateLocale();
 
   const previewDate = useMemo(() => new Date(2024, 7, 12, 14, 30, 0), []);

--- a/apps/client/src/components/server-screens/user-settings/others/index.tsx
+++ b/apps/client/src/components/server-screens/user-settings/others/index.tsx
@@ -1,4 +1,3 @@
-import { LanguageSwitcher } from '@/components/language-switcher';
 import { setAutoJoinLastChannel } from '@/features/app/actions';
 import { useAutoJoinLastChannel } from '@/features/app/hooks';
 import {
@@ -32,10 +31,6 @@ const Others = memo(() => {
             checked={autoJoinLastChannel}
             onCheckedChange={(value) => setAutoJoinLastChannel(value)}
           />
-        </Group>
-
-        <Group label={t('languageLabel')} description={t('languageDesc')}>
-          <LanguageSwitcher />
         </Group>
       </CardContent>
     </Card>

--- a/apps/client/src/helpers/storage.ts
+++ b/apps/client/src/helpers/storage.ts
@@ -26,7 +26,10 @@ export enum LocalStorageKey {
   BROWSER_NOTIFICATIONS = 'sharkord-browser-notifications',
   BROWSER_NOTIFICATIONS_FOR_MENTIONS = 'sharkord-browser-notifications-for-mentions',
   BROWSER_NOTIFICATIONS_FOR_DMS = 'sharkord-browser-notifications-for-dms',
-  LANGUAGE = 'sharkord-language'
+  LANGUAGE = 'sharkord-language',
+  DATE_FORMAT = 'sharkord-date-format',
+  TIME_FORMAT = 'sharkord-time-format',
+  PREFER_ABSOLUTE_TIME = 'sharkord-prefer-absolute-time'
 }
 
 export enum SessionStorageKey {

--- a/apps/client/src/hooks/use-date-format.ts
+++ b/apps/client/src/hooks/use-date-format.ts
@@ -1,0 +1,87 @@
+import {
+  getLocalStorageItem,
+  getLocalStorageItemBool,
+  LocalStorageKey,
+  setLocalStorageItem,
+  setLocalStorageItemBool
+} from '@/helpers/storage';
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+
+// Default formats
+const DEFAULT_DATE_FORMAT = 'PP';
+const DEFAULT_TIME_FORMAT = 'p';
+
+// Storage event listener
+const subscribe = (callback: () => void) => {
+  window.addEventListener('storage', callback);
+  return () => window.removeEventListener('storage', callback);
+};
+
+// Get snapshot for date format
+const getDateFormatSnapshot = () => {
+  return (
+    getLocalStorageItem(LocalStorageKey.DATE_FORMAT) ?? DEFAULT_DATE_FORMAT
+  );
+};
+
+// Get snapshot for time format
+const getTimeFormatSnapshot = () => {
+  return (
+    getLocalStorageItem(LocalStorageKey.TIME_FORMAT) ?? DEFAULT_TIME_FORMAT
+  );
+};
+
+// Get snapshot for prefer absolute time
+const getPreferAbsoluteTimeSnapshot = () => {
+  return getLocalStorageItemBool(LocalStorageKey.PREFER_ABSOLUTE_TIME, false);
+};
+
+export const useDateFormat = () => {
+  const dateFormat = useSyncExternalStore(
+    subscribe,
+    getDateFormatSnapshot,
+    getDateFormatSnapshot
+  );
+
+  const timeFormat = useSyncExternalStore(
+    subscribe,
+    getTimeFormatSnapshot,
+    getTimeFormatSnapshot
+  );
+
+  const preferAbsoluteTime = useSyncExternalStore(
+    subscribe,
+    getPreferAbsoluteTimeSnapshot,
+    getPreferAbsoluteTimeSnapshot
+  );
+
+  const setDateFormat = useCallback((format: string) => {
+    setLocalStorageItem(LocalStorageKey.DATE_FORMAT, format);
+    window.dispatchEvent(new Event('storage'));
+  }, []);
+
+  const setTimeFormat = useCallback((format: string) => {
+    setLocalStorageItem(LocalStorageKey.TIME_FORMAT, format);
+    window.dispatchEvent(new Event('storage'));
+  }, []);
+
+  const setPreferAbsoluteTime = useCallback((prefer: boolean) => {
+    setLocalStorageItemBool(LocalStorageKey.PREFER_ABSOLUTE_TIME, prefer);
+    window.dispatchEvent(new Event('storage'));
+  }, []);
+
+  // Combined date-time format (for timestamps)
+  const dateTimeFormat = useMemo(() => {
+    return `${dateFormat} ${timeFormat}`;
+  }, [dateFormat, timeFormat]);
+
+  return {
+    dateFormat,
+    timeFormat,
+    dateTimeFormat,
+    preferAbsoluteTime,
+    setDateFormat,
+    setTimeFormat,
+    setPreferAbsoluteTime
+  };
+};

--- a/apps/client/src/i18n/locales/en/settings.json
+++ b/apps/client/src/i18n/locales/en/settings.json
@@ -8,6 +8,7 @@
   "passwordTab": "Password",
   "notificationsTab": "Notifications",
   "othersTab": "Others",
+  "interfaceTab": "Interface",
   "serverSettingsTitle": "Server Settings",
   "generalTab": "General",
   "rolesTab": "Roles",
@@ -382,5 +383,14 @@
   "deleteFileTitle": "Delete file",
   "deleteFileMsg": "Are you sure you want to delete this file?",
   "fileDeletedSuccess": "File deleted successfully",
-  "failedDeleteFile": "Failed to delete file"
+  "failedDeleteFile": "Failed to delete file",
+
+  "dateFormatLabel": "Date Format",
+  "dateFormatDesc": "Choose how dates are displayed.",
+  "timeFormatLabel": "Time Format",
+  "timeFormatDesc": "Choose how times are displayed.",
+  "preferAbsoluteTimeLabel": "Always Show Absolute Time",
+  "preferAbsoluteTimeDesc": "Show absolute timestamps instead of relative time (e.g., \"2:30 PM\" instead of \"5 minutes ago\").",
+  "interfaceTitle": "Interface",
+  "interfaceDesc": "Customize the appearance and display settings."
 }

--- a/apps/client/src/i18n/locales/zh/settings.json
+++ b/apps/client/src/i18n/locales/zh/settings.json
@@ -8,6 +8,7 @@
   "passwordTab": "密码",
   "notificationsTab": "通知",
   "othersTab": "其他",
+  "interfaceTab": "界面",
   "serverSettingsTitle": "服务器设置",
   "generalTab": "常规",
   "rolesTab": "角色",
@@ -382,5 +383,14 @@
   "deleteFileTitle": "删除文件",
   "deleteFileMsg": "您确定要删除此文件吗？",
   "fileDeletedSuccess": "文件已成功删除",
-  "failedDeleteFile": "删除文件失败"
+  "failedDeleteFile": "删除文件失败",
+
+  "dateFormatLabel": "日期格式",
+  "dateFormatDesc": "选择日期的显示方式。",
+  "timeFormatLabel": "时间格式",
+  "timeFormatDesc": "选择时间的显示方式。",
+  "preferAbsoluteTimeLabel": "总是显示绝对时间",
+  "preferAbsoluteTimeDesc": "显示绝对时间戳而不是相对时间（例如，显示「下午 2:30」而不是「5 分钟前」）。",
+  "interfaceTitle": "界面",
+  "interfaceDesc": "自定义外观和显示设置。"
 }


### PR DESCRIPTION
## Summary

Closes #566

This PR adds user-configurable date and time format settings:
- Added options to choose date and time format (with presets and custom format support)
- Added an option to always show absolute time instead of relative time
- Added hover on relative time to view absolute time

The hover functionality required refactoring the `RelativeTime` component from a render prop pattern to directly returning a span element, which resulted in changes across multiple files. @diogomartino what do you think about this approach?

## Additional Context

The changes include:
- New `DateFormatSettings` component in user settings
- New `useDateFormat` hook using `useSyncExternalStore` for reactive localStorage
- Refactored `RelativeTime` component to support hover and preferAbsoluteTime
- i18n translations for English and Chinese

<img width="669" height="268" alt="sc" src="https://github.com/user-attachments/assets/9d4776e6-0785-4cc5-9302-5aee64e76445" />
