### PR TITLE
chore(565): add pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'


### PR DESCRIPTION
## Summary
This PR adds a pnpm-workspace.yaml file to the root of the project which is required for pnpm to recognize this as a monorepo workspace.

Closes #565