### PR TITLE
fix(240): hide the share screen controls when not supported

### DIFF
--- a/apps/client/src/components/channel-view/voice/controls-bar.tsx
+++ b/apps/client/src/components/channel-view/voice/controls-bar.tsx
@@ -22,7 +22,8 @@ type TControlsBarProps = {
 };
 
 const ControlsBar = memo(({ channelId }: TControlsBarProps) => {
-  const { toggleMic, toggleWebcam, toggleScreenShare } = useVoice();
+  const { toggleMic, toggleWebcam, toggleScreenShare, isScreenShareSupported } =
+    useVoice();
   const ownVoiceState = useOwnVoiceState();
   const channelCan = useChannelCan(channelId);
   const isVisible = useControlsBarVisibility();
@@ -73,16 +74,18 @@ const ControlsBar = memo(({ channelId }: TControlsBarProps) => {
           disabled={!permissions.canWebcam}
         />
 
-        <ControlToggleButton
-          enabled={ownVoiceState.sharingScreen}
-          enabledLabel="Stop Sharing"
-          disabledLabel="Share Screen"
-          enabledIcon={ScreenShareOff}
-          disabledIcon={Monitor}
-          enabledClassName="bg-blue-500/20 text-blue-500 hover:bg-blue-500/30 hover:text-blue-500"
-          onClick={toggleScreenShare}
-          disabled={!permissions.canShareScreen}
-        />
+        {isScreenShareSupported && (
+          <ControlToggleButton
+            enabled={ownVoiceState.sharingScreen}
+            enabledLabel="Stop Sharing"
+            disabledLabel="Share Screen"
+            enabledIcon={ScreenShareOff}
+            disabledIcon={Monitor}
+            enabledClassName="bg-blue-500/20 text-blue-500 hover:bg-blue-500/30 hover:text-blue-500"
+            onClick={toggleScreenShare}
+            disabled={!permissions.canShareScreen}
+          />
+        )}
       </div>
 
       <Tooltip content="Disconnect">

--- a/apps/client/src/components/left-sidebar/voice-control.tsx
+++ b/apps/client/src/components/left-sidebar/voice-control.tsx
@@ -26,8 +26,13 @@ const VoiceControl = memo(() => {
   const { t } = useTranslation('sidebar');
   const voiceChannelId = useCurrentVoiceChannelId();
   const channelCan = useChannelCan(voiceChannelId);
-  const { ownVoiceState, toggleWebcam, toggleScreenShare, connectionStatus } =
-    useVoice();
+  const {
+    ownVoiceState,
+    toggleWebcam,
+    toggleScreenShare,
+    connectionStatus,
+    isScreenShareSupported
+  } = useVoice();
 
   const connectionInfo = useMemo(() => {
     switch (connectionStatus) {
@@ -108,29 +113,31 @@ const VoiceControl = memo(() => {
               )}
             </Button>
 
-            <Button
-              variant="ghost"
-              size="icon"
-              className={cn(
-                'h-8 w-8 rounded-md transition-all duration-200',
-                ownVoiceState.sharingScreen
-                  ? 'bg-blue-500/15 hover:bg-blue-500/25 text-blue-400 hover:text-blue-300'
-                  : 'bg-secondary hover:bg-secondary/80 text-muted-foreground hover:text-foreground'
-              )}
-              onClick={toggleScreenShare}
-              title={
-                ownVoiceState.sharingScreen
-                  ? t('stopScreenShare')
-                  : t('startScreenShare')
-              }
-              disabled={!channelCan(ChannelPermission.SHARE_SCREEN)}
-            >
-              {ownVoiceState.sharingScreen ? (
-                <Monitor className="h-4 w-4" />
-              ) : (
-                <MonitorOff className="h-4 w-4" />
-              )}
-            </Button>
+            {isScreenShareSupported && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  'h-8 w-8 rounded-md transition-all duration-200',
+                  ownVoiceState.sharingScreen
+                    ? 'bg-blue-500/15 hover:bg-blue-500/25 text-blue-400 hover:text-blue-300'
+                    : 'bg-secondary hover:bg-secondary/80 text-muted-foreground hover:text-foreground'
+                )}
+                onClick={toggleScreenShare}
+                title={
+                  ownVoiceState.sharingScreen
+                    ? t('stopScreenShare')
+                    : t('startScreenShare')
+                }
+                disabled={!channelCan(ChannelPermission.SHARE_SCREEN)}
+              >
+                {ownVoiceState.sharingScreen ? (
+                  <Monitor className="h-4 w-4" />
+                ) : (
+                  <MonitorOff className="h-4 w-4" />
+                )}
+              </Button>
+            )}
           </div>
         </div>
       </div>

--- a/apps/client/src/components/voice-provider/index.tsx
+++ b/apps/client/src/components/voice-provider/index.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/helpers/audio-worklet/noise-gate-worklet';
 import { logVoice } from '@/helpers/browser-logger';
 import { getResWidthHeight } from '@/helpers/get-res-with-height';
+import { useScreenShareSupport } from '@/hooks/use-screen-share-support';
 import { getTRPCClient } from '@/lib/trpc';
 import { VideoCodec } from '@/types';
 import {
@@ -76,6 +77,7 @@ export type TVoiceProvider = {
   transportStats: TransportStatsData;
   audioVideoRefsMap: Map<number, AudioVideoRefs>;
   ownVoiceState: TVoiceUserState;
+  isScreenShareSupported: boolean;
   getOrCreateRefs: (remoteId: number) => AudioVideoRefs;
   getConsumerCodec: (remoteId: number, kind: StreamKind) => string | undefined;
   init: (
@@ -111,6 +113,7 @@ const VoiceProviderContext = createContext<TVoiceProvider>({
     averageBitrateSent: 0
   },
   audioVideoRefsMap: new Map(),
+  isScreenShareSupported: false,
   getOrCreateRefs: () => ({
     videoRef: { current: null },
     audioRef: { current: null },
@@ -153,6 +156,7 @@ const VoiceProvider = memo(({ children }: TVoiceProviderProps) => {
   const audioVideoRefsMap = useRef<Map<number, AudioVideoRefs>>(new Map());
   const ownVoiceState = useOwnVoiceState();
   const { devices } = useDevices();
+  const { isScreenShareSupported } = useScreenShareSupport();
 
   const getOrCreateRefs = useCallback((remoteId: number): AudioVideoRefs => {
     if (!audioVideoRefsMap.current.has(remoteId)) {
@@ -819,6 +823,7 @@ const VoiceProvider = memo(({ children }: TVoiceProviderProps) => {
       connectionStatus,
       transportStats,
       audioVideoRefsMap: audioVideoRefsMap.current,
+      isScreenShareSupported,
       getOrCreateRefs,
       getConsumerCodec,
       init,
@@ -841,6 +846,7 @@ const VoiceProvider = memo(({ children }: TVoiceProviderProps) => {
       loading,
       connectionStatus,
       transportStats,
+      isScreenShareSupported,
       getOrCreateRefs,
       getConsumerCodec,
       init,

--- a/apps/client/src/hooks/use-screen-share-support.ts
+++ b/apps/client/src/hooks/use-screen-share-support.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+
+/**
+ * Checks if screen sharing (getDisplayMedia) is supported on the current device.
+ * This API is not available on mobile browsers (iOS Safari, Android Chrome, etc.)
+ */
+const useScreenShareSupport = () => {
+  const isSupported = useMemo(() => {
+    if (typeof window === 'undefined') return false;
+    if (!navigator.mediaDevices) return false;
+
+    return typeof navigator.mediaDevices.getDisplayMedia === 'function';
+  }, []);
+
+  return { isScreenShareSupported: isSupported };
+};
+
+export { useScreenShareSupport };


### PR DESCRIPTION
## Summary
This PR conditionally hides the screen share controls when the current device does not support it.  The default is to hide the component, only allowing it to be displayed after we confirm the functionality is supported on the client's browser.

A new useMemo hook has been created for this purpose `use-screen-share-support.ts`.
Both the channel's `controls-bar` and the sidebar's `voice-control` components have been modified.

Closes #240