### PR TITLE
fix(604): don't treat disconnected as terminal

### DIFF
--- a/apps/client/src/components/channel-view/voice/controls-bar.tsx
+++ b/apps/client/src/components/channel-view/voice/controls-bar.tsx
@@ -95,7 +95,7 @@ const ControlsBar = memo(({ channelId }: TControlsBarProps) => {
             'pointer-events-auto h-14 w-18 rounded-md text-white shadow-xl transition-all active:scale-95',
             'bg-[#ec4245] hover:bg-[#da373c]'
           )}
-          onClick={() => void leaveVoice()}
+          onClick={() => leaveVoice()}
           aria-label="Disconnect"
         >
           <PhoneOff size={24} fill="currentColor" />

--- a/apps/client/src/components/channel-view/voice/controls-bar.tsx
+++ b/apps/client/src/components/channel-view/voice/controls-bar.tsx
@@ -95,7 +95,7 @@ const ControlsBar = memo(({ channelId }: TControlsBarProps) => {
             'pointer-events-auto h-14 w-18 rounded-md text-white shadow-xl transition-all active:scale-95',
             'bg-[#ec4245] hover:bg-[#da373c]'
           )}
-          onClick={leaveVoice}
+          onClick={() => void leaveVoice()}
           aria-label="Disconnect"
         >
           <PhoneOff size={24} fill="currentColor" />

--- a/apps/client/src/components/left-sidebar/voice-control.tsx
+++ b/apps/client/src/components/left-sidebar/voice-control.tsx
@@ -86,7 +86,9 @@ const VoiceControl = memo(() => {
           <Button
             variant="outline"
             size="sm"
-            onClick={() => void leaveVoice({ reason: 'user_disconnect_button' })}
+            onClick={() =>
+              void leaveVoice({ reason: 'user_disconnect_button' })
+            }
           >
             <PhoneOff className="h-3.5 w-3.5 mr-1.5" />
             {t('disconnectVoice')}

--- a/apps/client/src/components/left-sidebar/voice-control.tsx
+++ b/apps/client/src/components/left-sidebar/voice-control.tsx
@@ -83,7 +83,11 @@ const VoiceControl = memo(() => {
         </StatsPopover>
 
         <div className="flex items-center justify-between px-2 py-2">
-          <Button variant="outline" size="sm" onClick={leaveVoice}>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void leaveVoice({ reason: 'user_disconnect_button' })}
+          >
             <PhoneOff className="h-3.5 w-3.5 mr-1.5" />
             {t('disconnectVoice')}
           </Button>

--- a/apps/client/src/components/left-sidebar/voice-control.tsx
+++ b/apps/client/src/components/left-sidebar/voice-control.tsx
@@ -86,9 +86,7 @@ const VoiceControl = memo(() => {
           <Button
             variant="outline"
             size="sm"
-            onClick={() =>
-              void leaveVoice({ reason: 'user_disconnect_button' })
-            }
+            onClick={() => leaveVoice({ reason: 'user_disconnect_button' })}
           >
             <PhoneOff className="h-3.5 w-3.5 mr-1.5" />
             {t('disconnectVoice')}

--- a/apps/client/src/components/voice-provider/hooks/use-transports.ts
+++ b/apps/client/src/components/voice-provider/hooks/use-transports.ts
@@ -82,7 +82,7 @@ const useTransports = ({
       producerTransport.current.on('connectionstatechange', (state) => {
         logVoice('Producer transport connection state changed', { state });
 
-        if (state === 'failed' || state === 'disconnected') {
+        if (state === 'failed') {
           logVoice(`Producer transport ${state}`);
           producerTransport.current?.close();
         } else if (state === 'closed') {
@@ -169,7 +169,7 @@ const useTransports = ({
       consumerTransport.current.on('connectionstatechange', (state) => {
         logVoice('Consumer transport connection state changed', { state });
 
-        if (state === 'failed' || state === 'disconnected') {
+        if (state === 'failed') {
           logVoice(`Consumer transport ${state}, attempting cleanup`);
 
           Object.values(consumers.current).forEach((userConsumers) => {

--- a/apps/client/src/features/server/voice/actions.ts
+++ b/apps/client/src/features/server/voice/actions.ts
@@ -5,6 +5,7 @@ import {
   setLocalStorageItem,
   setLocalStorageItemBool
 } from '@/helpers/storage';
+import { logVoice } from '@/helpers/browser-logger';
 import { getTRPCClient } from '@/lib/trpc';
 import {
   getTrpcError,
@@ -152,7 +153,7 @@ export const joinVoice = async (
 
   if (currentChannelId) {
     // is already in a voice channel, leave it first
-    await leaveVoice();
+    await leaveVoice({ reason: 'switch_channel' });
   }
 
   setCurrentVoiceChannelId(channelId);
@@ -174,14 +175,31 @@ export const joinVoice = async (
   return undefined;
 };
 
-export const leaveVoice = async (): Promise<void> => {
+export type TLeaveVoiceReason =
+  | 'user_disconnect_button'
+  | 'switch_channel'
+  | 'unknown';
+
+export const leaveVoice = async (
+  options?: {
+    reason?: TLeaveVoiceReason;
+  }
+): Promise<void> => {
   const state = store.getState();
   const currentChannelId = currentVoiceChannelIdSelector(state);
   const selectedChannelId = selectedChannelIdSelector(state);
+  const reason = options?.reason ?? 'unknown';
 
   if (!currentChannelId) {
+    logVoice('Leave voice requested without active channel', { reason });
     return;
   }
+
+  logVoice('Leave voice requested', {
+    reason,
+    channelId: currentChannelId,
+    selectedChannelId
+  });
 
   if (selectedChannelId === currentChannelId) {
     setSelectedChannelId(undefined);

--- a/apps/client/src/features/server/voice/actions.ts
+++ b/apps/client/src/features/server/voice/actions.ts
@@ -1,11 +1,11 @@
 import type { TPinnedCard } from '@/components/channel-view/voice/hooks/use-pin-card-controller';
 import { store } from '@/features/store';
+import { logVoice } from '@/helpers/browser-logger';
 import {
   LocalStorageKey,
   setLocalStorageItem,
   setLocalStorageItemBool
 } from '@/helpers/storage';
-import { logVoice } from '@/helpers/browser-logger';
 import { getTRPCClient } from '@/lib/trpc';
 import {
   getTrpcError,
@@ -180,11 +180,9 @@ export type TLeaveVoiceReason =
   | 'switch_channel'
   | 'unknown';
 
-export const leaveVoice = async (
-  options?: {
-    reason?: TLeaveVoiceReason;
-  }
-): Promise<void> => {
+export const leaveVoice = async (options?: {
+  reason?: TLeaveVoiceReason;
+}): Promise<void> => {
   const state = store.getState();
   const currentChannelId = currentVoiceChannelIdSelector(state);
   const selectedChannelId = selectedChannelIdSelector(state);


### PR DESCRIPTION
## Summary

Sharkord currently treats mediasoup/WebRTC transport state 'disconnected' as a hard failure. This is incorrect: under temporary network degradation the transport often recovers to 'connected' on its own. Because of this, Sharkord tears down voice sessions prematurely instead of allowing transient disconnects to recover.

Closes #604 

## Additional Context

This is from testing for #552 - I removed all the reconnect stuff and reduced the change to only dealing with the mediasoup transport state. Testing with `tc` as well as a full game session with a friend with bad internet seemed to show that all `disconnected` states were recoverable.

Additionally, there is a tiny helper that shows a reason when using leaveVoice()