### PR TITLE
feat(613): responsive grid layout in voice channels

### DIFF
--- a/apps/client/src/components/channel-view/voice/voice-grid.tsx
+++ b/apps/client/src/components/channel-view/voice/voice-grid.tsx
@@ -1,5 +1,13 @@
 import { cn } from '@/lib/utils';
-import { isValidElement, memo, useMemo, type ReactNode } from 'react';
+import {
+  isValidElement,
+  memo,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode
+} from 'react';
 
 type TVoiceGridProps = {
   children: ReactNode[];
@@ -7,9 +15,81 @@ type TVoiceGridProps = {
   className?: string;
 };
 
+const OPTIMAL_CELL_ASPECT_RATIO = 1.5;
+
 const VoiceGrid = memo(
   ({ children, pinnedCardId, className }: TVoiceGridProps) => {
-    const { gridCols, pinnedCard, regularCards } = useMemo(() => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [containerSize, setContainerSize] = useState<{
+      width: number;
+      height: number;
+    } | null>(null);
+
+    useLayoutEffect(() => {
+      const element = containerRef.current;
+      if (!element) return;
+
+      const updateSize = () => {
+        const rect = element.getBoundingClientRect();
+        setContainerSize({ width: rect.width, height: rect.height });
+      };
+
+      updateSize();
+
+      const resizeObserver = new ResizeObserver(updateSize);
+      resizeObserver.observe(element);
+
+      return () => resizeObserver.disconnect();
+    }, []);
+
+    const calculateOptimalGrid = (
+      totalCards: number,
+      containerWidth: number,
+      containerHeight: number
+    ) => {
+      if (totalCards <= 1 || containerWidth <= 0 || containerHeight <= 0) {
+        return { cols: 1 };
+      }
+
+      const maxCols = totalCards;
+
+      let bestCols = 1;
+      let bestScore = Infinity;
+
+      for (let cols = 1; cols <= maxCols; cols++) {
+        const rows = Math.ceil(totalCards / cols);
+        const cellWidth = containerWidth / cols;
+        const cellHeight = containerHeight / rows;
+        const cellAspectRatio = cellWidth / cellHeight;
+
+        const score = Math.abs(cellAspectRatio - OPTIMAL_CELL_ASPECT_RATIO);
+        if (score < bestScore) {
+          bestScore = score;
+          bestCols = cols;
+        }
+      }
+
+      return { cols: bestCols };
+    };
+
+    const gridCols = useMemo(() => {
+      const childArray = Array.isArray(children) ? children : [children];
+      const totalCards = childArray.length;
+
+      if (!containerSize) {
+        return 1;
+      }
+
+      const { cols } = calculateOptimalGrid(
+        totalCards,
+        containerSize.width,
+        containerSize.height
+      );
+
+      return cols;
+    }, [children, containerSize]);
+
+    const { pinnedCard, regularCards } = useMemo(() => {
       const childArray = Array.isArray(children) ? children : [children];
 
       if (pinnedCardId) {
@@ -23,46 +103,11 @@ const VoiceGrid = memo(
             !isValidElement(child) || child.key !== pinnedCardId
         );
 
-        return {
-          gridCols: regular.length <= 4 ? regular.length : 4,
-          pinnedCard: pinned,
-          regularCards: regular
-        };
+        return { pinnedCard: pinned, regularCards: regular };
       }
 
-      const totalCards = childArray.length;
-
-      let cols = 1;
-
-      if (totalCards <= 1) cols = 1;
-      else if (totalCards <= 4) cols = 2;
-      else if (totalCards <= 9) cols = 3;
-      else if (totalCards <= 16) cols = 4;
-      else cols = 5;
-
-      return {
-        gridCols: cols,
-        pinnedCard: null,
-        regularCards: childArray
-      };
+      return { pinnedCard: null, regularCards: childArray };
     }, [children, pinnedCardId]);
-
-    const getGridClass = (cols: number) => {
-      switch (cols) {
-        case 1:
-          return 'grid-cols-1';
-        case 2:
-          return 'grid-cols-2';
-        case 3:
-          return 'grid-cols-3';
-        case 4:
-          return 'grid-cols-4';
-        case 5:
-          return 'grid-cols-5';
-        default:
-          return 'grid-cols-4';
-      }
-    };
 
     if (pinnedCardId && pinnedCard) {
       return (
@@ -71,7 +116,7 @@ const VoiceGrid = memo(
 
           {regularCards.length > 0 && (
             <div className="flex-shrink-0 border-t border-border bg-card/50">
-              <div className="flex justify-center gap-2 p-2 overflow-x-auto">
+              <div className="flex justify-center-safe gap-2 p-2 overflow-x-auto">
                 {regularCards.map((card, index) => (
                   <div key={index} className="flex-shrink-0 w-40 h-24">
                     {card}
@@ -84,39 +129,33 @@ const VoiceGrid = memo(
       );
     }
 
-    const getRowCount = (totalCards: number, cols: number) => {
-      return Math.ceil(totalCards / cols);
-    };
-
-    const getGridRowsClass = (rows: number) => {
-      switch (rows) {
-        case 1:
-          return 'grid-rows-1';
-        case 2:
-          return 'grid-rows-2';
-        case 3:
-          return 'grid-rows-3';
-        case 4:
-          return 'grid-rows-4';
-        case 5:
-          return 'grid-rows-5';
-        default:
-          return 'grid-rows-4';
-      }
-    };
-
-    const rows = getRowCount(regularCards.length, gridCols);
+    const rows = Math.ceil(regularCards.length / gridCols);
+    const lastRowCount = regularCards.length % gridCols || gridCols;
+    const lastRowOffset =
+      lastRowCount < gridCols ? ((gridCols - lastRowCount) / 2) * 100 : 0;
+    const lastRowStart = regularCards.length - lastRowCount;
 
     return (
       <div
-        className={cn(
-          'grid h-full p-2 gap-2',
-          getGridClass(gridCols),
-          getGridRowsClass(rows),
-          className
-        )}
+        ref={containerRef}
+        className={cn('grid h-full w-full gap-2 p-2', className)}
+        style={{
+          gridTemplateColumns: `repeat(${gridCols}, 1fr)`,
+          gridTemplateRows: `repeat(${rows}, 1fr)`
+        }}
       >
-        {regularCards}
+        {regularCards.map((card, index) => (
+          <div
+            key={isValidElement(card) ? card.key : index}
+            style={
+              lastRowOffset && index >= lastRowStart
+                ? { transform: `translateX(${lastRowOffset}%)` }
+                : undefined
+            }
+          >
+            {card}
+          </div>
+        ))}
       </div>
     );
   }


### PR DESCRIPTION
## Summary

This makes the layout of cards in video channels responsive to the dimensions of the viewport.

Closes #613
Alternative to #617 

## Additional Context

https://github.com/user-attachments/assets/33fc3a0d-c0e7-4d78-87da-37522bd20242

In this approach, we compute the number of rows and columns that will result in cards having the most natural aspect ratio.  If the space is very narrow, cards end up in a column.  If the space is very wide, cards end up in a row.

<img width="20%" height="1375" alt="Screenshot from 2026-03-23 23-48-12" src="https://github.com/user-attachments/assets/ee76276b-aa65-43ba-945e-c899dbe15b64" />

<img width="30%" height="1097" alt="Screenshot from 2026-03-23 23-48-29" src="https://github.com/user-attachments/assets/fd0308ef-4ebb-41eb-9d53-3ab87abdec41" />

<img width="40%" height="904" alt="Screenshot from 2026-03-23 23-48-50" src="https://github.com/user-attachments/assets/90d6b9b4-60d8-4999-8041-aded3d1e3843" />

<img width="60%" height="574" alt="Screenshot from 2026-03-23 23-49-13" src="https://github.com/user-attachments/assets/ea7574f2-9952-4a5f-bbbb-ee16bafc852e" />

### Scrolling fix

This PR also includes a fix for a rough bug when a card is pinned, where if there are enough participants in the channel, some can flow off the left of the scrolling bar at the bottom so as to be completely unreachable.  The fix is to use `justify-center-safe` instead of `justify-center`.

<img width="400" height="920" alt="Screenshot from 2026-03-23 23-55-00" src="https://github.com/user-attachments/assets/8031af9a-c4ca-4522-baae-84689ce35fe2" />

> Without this fix, it is impossible to scroll the left-most item into view

Let me know if you want this to be separated out, but it's just a change of a css class name.