### PR TITLE
fix(635): don't let users toggle camera/mic if already in progress

### DIFF
--- a/apps/client/src/components/voice-provider/hooks/use-voice-controls.ts
+++ b/apps/client/src/components/voice-provider/hooks/use-voice-controls.ts
@@ -5,7 +5,7 @@ import { updateOwnVoiceState } from '@/features/server/voice/actions';
 import { useOwnVoiceState } from '@/features/server/voice/hooks';
 import { getTRPCClient } from '@/lib/trpc';
 import { getTrpcError } from '@sharkord/shared';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { toast } from 'sonner';
 
 type TUseVoiceControlsParams = {
@@ -30,7 +30,14 @@ const useVoiceControls = ({
   const ownVoiceState = useOwnVoiceState();
   const currentVoiceChannelId = useCurrentVoiceChannelId();
 
+  const isTogglingMic = useRef(false);
+  const isTogglingSound = useRef(false);
+  const isTogglingWebcam = useRef(false);
+  const isTogglingScreenShare = useRef(false);
+
   const toggleMic = useCallback(async () => {
+    if (isTogglingMic.current) return;
+    isTogglingMic.current = true;
     const newState = !ownVoiceState.micMuted;
     const trpc = getTRPCClient();
 
@@ -39,7 +46,10 @@ const useVoiceControls = ({
       newState ? SoundType.OWN_USER_MUTED_MIC : SoundType.OWN_USER_UNMUTED_MIC
     );
 
-    if (!currentVoiceChannelId) return;
+    if (!currentVoiceChannelId) {
+      isTogglingMic.current = false;
+      return;
+    }
 
     try {
       await trpc.voice.updateState.mutate({
@@ -52,6 +62,8 @@ const useVoiceControls = ({
     } catch (error) {
       updateOwnVoiceState({ micMuted: !newState });
       toast.error(getTrpcError(error, 'Failed to update microphone state'));
+    } finally {
+      isTogglingMic.current = false;
     }
   }, [
     ownVoiceState.micMuted,
@@ -61,6 +73,9 @@ const useVoiceControls = ({
   ]);
 
   const toggleSound = useCallback(async () => {
+    if (isTogglingSound.current) return;
+    isTogglingSound.current = true;
+
     const newState = !ownVoiceState.soundMuted;
     const trpc = getTRPCClient();
 
@@ -71,7 +86,10 @@ const useVoiceControls = ({
         : SoundType.OWN_USER_UNMUTED_SOUND
     );
 
-    if (!currentVoiceChannelId) return;
+    if (!currentVoiceChannelId) {
+      isTogglingSound.current = false;
+      return;
+    }
 
     try {
       await trpc.voice.updateState.mutate({
@@ -79,11 +97,15 @@ const useVoiceControls = ({
       });
     } catch (error) {
       toast.error(getTrpcError(error, 'Failed to update sound state'));
+    } finally {
+      isTogglingSound.current = false;
     }
   }, [ownVoiceState.soundMuted, currentVoiceChannelId]);
 
   const toggleWebcam = useCallback(async () => {
     if (!currentVoiceChannelId) return;
+    if (isTogglingWebcam.current) return;
+    isTogglingWebcam.current = true;
 
     const newState = !ownVoiceState.webcamEnabled;
     const trpc = getTRPCClient();
@@ -116,6 +138,8 @@ const useVoiceControls = ({
       }
 
       toast.error(getTrpcError(error, 'Failed to update webcam state'));
+    } finally {
+      isTogglingWebcam.current = false;
     }
   }, [
     ownVoiceState.webcamEnabled,
@@ -125,6 +149,9 @@ const useVoiceControls = ({
   ]);
 
   const toggleScreenShare = useCallback(async () => {
+    if (isTogglingScreenShare.current) return;
+    isTogglingScreenShare.current = true;
+
     const newState = !ownVoiceState.sharingScreen;
     const trpc = getTRPCClient();
 
@@ -170,6 +197,8 @@ const useVoiceControls = ({
       }
 
       toast.error(getTrpcError(error, 'Failed to update screen share state'));
+    } finally {
+      isTogglingScreenShare.current = false;
     }
   }, [
     ownVoiceState.sharingScreen,


### PR DESCRIPTION
## Summary

In this PR we disregard repeated clicks on camera/mic/screenshare/deafen buttons if we're already in the process of toggling state.

Closes #635

## Additional Context

This addresses a very not-nice bug where a user can think their camera is off, but everyone else in the call can actually see them.  This also prevents piling up of "choose the screen to share" firefox dialogs if the user keeps pressing the screenshare button.

This all can happen in real life conditions, when an under-powered device is having trouble being responsive to UI events, and a frustrated user is repeatedly hitting the buttons in quick succession.

Some test cases:

- While in a voice channel we should be able to click *really fast* on the camera/mic/deafen toggles and everyone ends up seeing the same on/off state.

- In Firefox, we should be able to click repeatedly on "Start screen share" and see only one "Choose your screen" dialog.

- While not in a voice channel, we should be able to toggle mic and deafen states and see those settings honored when joining a voice channel.

