### PR TITLE
Add owner-initiated password reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 /DockerCenas
 /experiments
 .direnv/
+
+# Agentic workflow docs
+CLAUDE.md
+docs/CLAUDE.md

--- a/apps/client/src/components/mod-view-sheet/header.tsx
+++ b/apps/client/src/components/mod-view-sheet/header.tsx
@@ -14,7 +14,7 @@ import {
   UserStatus
 } from '@sharkord/shared';
 import { Button } from '@sharkord/ui';
-import { Gavel, Plus, Trash, UserMinus } from 'lucide-react';
+import { Gavel, KeyRound, Plus, Trash, UserMinus } from 'lucide-react';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
@@ -149,6 +149,31 @@ const Header = memo(() => {
     }
   }, [user.id, refetch, isDeletedUser, t]);
 
+  const onResetPassword = useCallback(async () => {
+    const newPassword = await requestTextInput({
+      title: t('resetPasswordTitle'),
+      message: t('resetPasswordMsg'),
+      confirmLabel: t('resetPasswordConfirm'),
+      type: 'password'
+    });
+
+    if (!newPassword) {
+      return;
+    }
+
+    const trpc = getTRPCClient();
+
+    try {
+      await trpc.users.resetPassword.mutate({
+        userId: user.id,
+        newPassword
+      });
+      toast.success(t('resetPasswordSuccess'));
+    } catch (error) {
+      toast.error(getTrpcError(error, t('failedResetPassword')));
+    }
+  }, [user.id, t]);
+
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-3">
@@ -174,6 +199,15 @@ const Header = memo(() => {
         >
           <Gavel className="h-4 w-4" />
           {user.banned ? t('unbanBtn') : t('banBtn')}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onResetPassword}
+          disabled={isOwnUser || isDeletedUser}
+        >
+          <KeyRound className="h-4 w-4" />
+          {t('resetPasswordBtn')}
         </Button>
         <Button
           variant="outline"

--- a/apps/client/src/i18n/locales/en/settings.json
+++ b/apps/client/src/i18n/locales/en/settings.json
@@ -355,6 +355,12 @@
   "unbanBtn": "Unban",
   "unbannedSuccess": "User unbanned successfully",
   "failedUnban": "Failed to unban user",
+  "resetPasswordTitle": "Reset Password",
+  "resetPasswordMsg": "Enter a new password for this user.",
+  "resetPasswordConfirm": "Reset",
+  "resetPasswordBtn": "Reset Password",
+  "resetPasswordSuccess": "Password reset successfully",
+  "failedResetPassword": "Failed to reset password",
   "deleteBtn": "Delete",
   "modViewAssignRoleBtn": "Assign Role",
 

--- a/apps/server/src/routers/users/index.ts
+++ b/apps/server/src/routers/users/index.ts
@@ -15,6 +15,7 @@ import { getUserInfoRoute } from './get-user-info';
 import { getUsersRoute } from './get-users';
 import { kickRoute } from './kick';
 import { removeRoleRoute } from './remove-role';
+import { resetPasswordRoute } from './reset-password';
 import { unbanRoute } from './unban';
 import { updatePasswordRoute } from './update-password';
 import { updateUserRoute } from './update-user';
@@ -26,6 +27,7 @@ export const usersRouter = t.router({
   removeRole: removeRoleRoute,
   update: updateUserRoute,
   updatePassword: updatePasswordRoute,
+  resetPassword: resetPasswordRoute,
   getInfo: getUserInfoRoute,
   getAll: getUsersRoute,
   kick: kickRoute,

--- a/apps/server/src/routers/users/reset-password.ts
+++ b/apps/server/src/routers/users/reset-password.ts
@@ -1,0 +1,52 @@
+import { ActivityLogType, Permission } from '@sharkord/shared';
+import { eq } from 'drizzle-orm';
+import z from 'zod';
+import { db } from '../../db';
+import { users } from '../../db/schema';
+import { enqueueActivityLog } from '../../queues/activity-log';
+import { invariant } from '../../utils/invariant';
+import { protectedProcedure } from '../../utils/trpc';
+
+const resetPasswordRoute = protectedProcedure
+  .input(
+    z.object({
+      userId: z.number(),
+      newPassword: z.string().min(4).max(128)
+    })
+  )
+  .mutation(async ({ ctx, input }) => {
+    await ctx.needsPermission(Permission.MANAGE_USERS);
+
+    invariant(input.userId !== ctx.user.id, {
+      code: 'BAD_REQUEST',
+      message: 'Use the change password flow for your own account.'
+    });
+
+    const user = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.id, input.userId))
+      .get();
+
+    invariant(user, {
+      code: 'NOT_FOUND',
+      message: 'User not found'
+    });
+
+    const hashedPassword = await Bun.password.hash(input.newPassword);
+
+    await db
+      .update(users)
+      .set({ password: hashedPassword })
+      .where(eq(users.id, input.userId));
+
+    enqueueActivityLog({
+      type: ActivityLogType.USER_PASSWORD_RESET,
+      userId: input.userId,
+      details: {
+        resetBy: ctx.userId
+      }
+    });
+  });
+
+export { resetPasswordRoute };

--- a/apps/server/src/routers/users/reset-password.ts
+++ b/apps/server/src/routers/users/reset-password.ts
@@ -1,7 +1,8 @@
-import { ActivityLogType, Permission } from '@sharkord/shared';
+import { ActivityLogType, OWNER_ROLE_ID, Permission } from '@sharkord/shared';
 import { eq } from 'drizzle-orm';
 import z from 'zod';
 import { db } from '../../db';
+import { getUserRoleIds } from '../../db/queries/roles';
 import { users } from '../../db/schema';
 import { enqueueActivityLog } from '../../queues/activity-log';
 import { invariant } from '../../utils/invariant';
@@ -31,6 +32,12 @@ const resetPasswordRoute = protectedProcedure
     invariant(user, {
       code: 'NOT_FOUND',
       message: 'User not found'
+    });
+
+    const targetRoles = await getUserRoleIds(input.userId);
+    invariant(!targetRoles.includes(OWNER_ROLE_ID), {
+      code: 'FORBIDDEN',
+      message: 'Cannot reset the password of an owner.'
     });
 
     const hashedPassword = await Bun.password.hash(input.newPassword);

--- a/packages/shared/src/logs.ts
+++ b/packages/shared/src/logs.ts
@@ -14,6 +14,7 @@ export enum ActivityLogType {
   USER_UNBANNED = 'USER_UNBANNED',
   USER_DELETED = 'USER_DELETED',
   USER_UPDATED_PASSWORD = 'USER_UPDATED_PASSWORD',
+  USER_PASSWORD_RESET = 'USER_PASSWORD_RESET',
   // -------------------- ROLES --------------------
   CREATED_ROLE = 'CREATED_ROLE',
   DELETED_ROLE = 'DELETED_ROLE',
@@ -77,6 +78,9 @@ export type TActivityLogDetailsMap = {
   };
   [ActivityLogType.USER_LEFT]: {};
   [ActivityLogType.USER_UPDATED_PASSWORD]: {};
+  [ActivityLogType.USER_PASSWORD_RESET]: {
+    resetBy: number;
+  };
   // -------------------- ROLES --------------------
   [ActivityLogType.CREATED_ROLE]: {
     roleId: number;


### PR DESCRIPTION
## Summary
- New `users.resetPassword` tRPC mutation (requires MANAGE_USERS permission, Argon2 hash, audit logged)
- Reset Password button in mod view header alongside kick/ban/delete
- i18n strings for EN locale

## Test plan
- [x] Tested locally via dev.sh — reset password flow works end-to-end