### PR TITLE
bug(669): Assert that uploaded logo is an image

### DIFF
--- a/apps/client/src/components/dialogs/welcome-profile-setup/index.tsx
+++ b/apps/client/src/components/dialogs/welcome-profile-setup/index.tsx
@@ -2,7 +2,7 @@ import { useServerName } from '@/features/server/hooks';
 import { useOwnPublicUser } from '@/features/server/users/hooks';
 import { getFileUrl } from '@/helpers/get-file-url';
 import { getInitialsFromName } from '@/helpers/get-initials-from-name';
-import { uploadFile } from '@/helpers/upload-file';
+import { uploadImage } from '@/helpers/upload-file';
 import { useFilePicker } from '@/hooks/use-file-picker';
 import { useForm } from '@/hooks/use-form';
 import { getTRPCClient } from '@/lib/trpc';
@@ -48,7 +48,7 @@ const WelcomeProfileSetupDialog = memo(
       try {
         const [file] = await openFilePicker('image/*');
 
-        const temporaryFile = await uploadFile(file);
+        const [temporaryFile, _] = await uploadImage(file);
 
         if (!temporaryFile) {
           toast.error(t('welcomeUploadError'));
@@ -77,7 +77,7 @@ const WelcomeProfileSetupDialog = memo(
       try {
         const [file] = await openFilePicker('image/*');
 
-        const temporaryFile = await uploadFile(file);
+        const [temporaryFile, _] = await uploadImage(file);
 
         if (!temporaryFile) {
           toast.error(t('welcomeUploadError'));

--- a/apps/client/src/components/dialogs/welcome-profile-setup/index.tsx
+++ b/apps/client/src/components/dialogs/welcome-profile-setup/index.tsx
@@ -48,10 +48,9 @@ const WelcomeProfileSetupDialog = memo(
       try {
         const [file] = await openFilePicker('image/*');
 
-        const [temporaryFile, _] = await uploadImage(file);
+        const temporaryFile = await uploadImage(file);
 
         if (!temporaryFile) {
-          toast.error(t('welcomeUploadError'));
           return;
         }
 
@@ -77,10 +76,9 @@ const WelcomeProfileSetupDialog = memo(
       try {
         const [file] = await openFilePicker('image/*');
 
-        const [temporaryFile, _] = await uploadImage(file);
+        const temporaryFile = await uploadImage(file);
 
         if (!temporaryFile) {
-          toast.error(t('welcomeUploadError'));
           return;
         }
 

--- a/apps/client/src/components/server-screens/server-settings/general/logo-manager.tsx
+++ b/apps/client/src/components/server-screens/server-settings/general/logo-manager.tsx
@@ -1,5 +1,5 @@
 import { ImagePicker } from '@/components/image-picker';
-import { uploadFile } from '@/helpers/upload-file';
+import { uploadImage } from '@/helpers/upload-file';
 import { useFilePicker } from '@/hooks/use-file-picker';
 import { getTRPCClient } from '@/lib/trpc';
 import type { TFile } from '@sharkord/shared';
@@ -35,10 +35,10 @@ const LogoManager = memo(({ logo, refetch }: TLogoManagerProps) => {
     try {
       const [file] = await openFilePicker('image/*');
 
-      const temporaryFile = await uploadFile(file);
+      const [temporaryFile, errorMsg] = await uploadImage(file);
 
       if (!temporaryFile) {
-        toast.error('Could not upload file. Please try again.');
+        toast.error(errorMsg);
         return;
       }
 

--- a/apps/client/src/components/server-screens/server-settings/general/logo-manager.tsx
+++ b/apps/client/src/components/server-screens/server-settings/general/logo-manager.tsx
@@ -35,10 +35,9 @@ const LogoManager = memo(({ logo, refetch }: TLogoManagerProps) => {
     try {
       const [file] = await openFilePicker('image/*');
 
-      const [temporaryFile, errorMsg] = await uploadImage(file);
+      const temporaryFile = await uploadImage(file);
 
       if (!temporaryFile) {
-        toast.error(errorMsg);
         return;
       }
 

--- a/apps/client/src/components/server-screens/user-settings/profile/avatar-manager.tsx
+++ b/apps/client/src/components/server-screens/user-settings/profile/avatar-manager.tsx
@@ -1,5 +1,5 @@
 import { UserAvatar } from '@/components/user-avatar';
-import { uploadFile } from '@/helpers/upload-file';
+import { uploadImage } from '@/helpers/upload-file';
 import { useFilePicker } from '@/hooks/use-file-picker';
 import { getTRPCClient } from '@/lib/trpc';
 import { getTrpcError, type TJoinedPublicUser } from '@sharkord/shared';
@@ -33,10 +33,10 @@ const AvatarManager = memo(({ user }: TAvatarManagerProps) => {
     try {
       const [file] = await openFilePicker('image/*');
 
-      const temporaryFile = await uploadFile(file);
+      const [temporaryFile, errorMsg] = await uploadImage(file);
 
       if (!temporaryFile) {
-        toast.error('Could not upload file. Please try again.');
+        toast.error(errorMsg);
         return;
       }
 

--- a/apps/client/src/components/server-screens/user-settings/profile/avatar-manager.tsx
+++ b/apps/client/src/components/server-screens/user-settings/profile/avatar-manager.tsx
@@ -33,10 +33,9 @@ const AvatarManager = memo(({ user }: TAvatarManagerProps) => {
     try {
       const [file] = await openFilePicker('image/*');
 
-      const [temporaryFile, errorMsg] = await uploadImage(file);
+      const temporaryFile = await uploadImage(file);
 
       if (!temporaryFile) {
-        toast.error(errorMsg);
         return;
       }
 

--- a/apps/client/src/components/server-screens/user-settings/profile/banner-manager.tsx
+++ b/apps/client/src/components/server-screens/user-settings/profile/banner-manager.tsx
@@ -1,5 +1,5 @@
 import { getFileUrl } from '@/helpers/get-file-url';
-import { uploadFile } from '@/helpers/upload-file';
+import { uploadImage } from '@/helpers/upload-file';
 import { useFilePicker } from '@/hooks/use-file-picker';
 import { getTRPCClient } from '@/lib/trpc';
 import { cn } from '@/lib/utils';
@@ -34,10 +34,10 @@ const BannerManager = memo(({ user }: TBannerManagerProps) => {
     try {
       const [file] = await openFilePicker('image/*');
 
-      const temporaryFile = await uploadFile(file);
+      const [temporaryFile, errorMsg] = await uploadImage(file);
 
       if (!temporaryFile) {
-        toast.error('Could not upload file. Please try again.');
+        toast.error(errorMsg);
         return;
       }
 

--- a/apps/client/src/components/server-screens/user-settings/profile/banner-manager.tsx
+++ b/apps/client/src/components/server-screens/user-settings/profile/banner-manager.tsx
@@ -34,10 +34,9 @@ const BannerManager = memo(({ user }: TBannerManagerProps) => {
     try {
       const [file] = await openFilePicker('image/*');
 
-      const [temporaryFile, errorMsg] = await uploadImage(file);
+      const temporaryFile = await uploadImage(file);
 
       if (!temporaryFile) {
-        toast.error(errorMsg);
         return;
       }
 

--- a/apps/client/src/helpers/upload-file.ts
+++ b/apps/client/src/helpers/upload-file.ts
@@ -21,8 +21,10 @@ const getSafeFileName = (name: string) => {
 const uploadImage = async (
   file: File
 ): Promise<[upload: TTempFile | undefined, errorMsg: string]> => {
+  if (!file) return [undefined, 'No file selected. Please try again.'];
+  
   if (!file.type.startsWith('image/')) {
-    return [undefined, 'Invalid file type. Please Try Again.'];
+    return [undefined, 'Invalid file type. Please try Again.'];
   }
 
   const tempFile = await uploadFile(file);

--- a/apps/client/src/helpers/upload-file.ts
+++ b/apps/client/src/helpers/upload-file.ts
@@ -22,7 +22,7 @@ const uploadImage = async (
   file: File
 ): Promise<[upload: TTempFile | undefined, errorMsg: string]> => {
   if (!file) return [undefined, 'No file selected. Please try again.'];
-  
+
   if (!file.type.startsWith('image/')) {
     return [undefined, 'Invalid file type. Please try Again.'];
   }

--- a/apps/client/src/helpers/upload-file.ts
+++ b/apps/client/src/helpers/upload-file.ts
@@ -13,6 +13,26 @@ const getSafeFileName = (name: string) => {
   );
 };
 
+/**
+ * Uploads an image file to the server. Validates that the file is an image before uploading.
+ * @param file The image file to upload.
+ * @returns A tuple containing the uploaded file information and an error message, if any.
+ */
+const uploadImage = async (
+  file: File
+): Promise<[upload: TTempFile | undefined, errorMsg: string]> => {
+  if (!file.type.startsWith('image/')) {
+    return [undefined, 'Invalid file type. Please Try Again.'];
+  }
+
+  const tempFile = await uploadFile(file);
+  if (!tempFile) {
+    return [undefined, 'Upload failed. Please try again.'];
+  }
+
+  return [tempFile, ''];
+};
+
 type TUploadProgress = {
   loaded: number;
   total: number;
@@ -102,4 +122,4 @@ const uploadFiles = async (
   return uploadedFiles;
 };
 
-export { uploadFile, uploadFiles, type TUploadProgress };
+export { uploadFile, uploadFiles, uploadImage, type TUploadProgress };

--- a/apps/client/src/helpers/upload-file.ts
+++ b/apps/client/src/helpers/upload-file.ts
@@ -16,7 +16,7 @@ const getSafeFileName = (name: string) => {
 /**
  * Uploads an image file to the server. Validates that the file is an image before uploading.
  * @param file The image file to upload.
- * @returns A tuple containing the uploaded file information and an error message, if any.
+ * @returns A TTempFile containing the uploaded file information, if successful.
  */
 const uploadImage = async (file: File): Promise<TTempFile | undefined> => {
   if (!file) {

--- a/apps/client/src/helpers/upload-file.ts
+++ b/apps/client/src/helpers/upload-file.ts
@@ -13,11 +13,6 @@ const getSafeFileName = (name: string) => {
   );
 };
 
-/**
- * Uploads an image file to the server. Validates that the file is an image before uploading.
- * @param file The image file to upload.
- * @returns A TTempFile containing the uploaded file information, if successful.
- */
 const uploadImage = async (file: File): Promise<TTempFile | undefined> => {
   if (!file) {
     toast.error('No file selected. Please try again.');

--- a/apps/client/src/helpers/upload-file.ts
+++ b/apps/client/src/helpers/upload-file.ts
@@ -18,21 +18,18 @@ const getSafeFileName = (name: string) => {
  * @param file The image file to upload.
  * @returns A tuple containing the uploaded file information and an error message, if any.
  */
-const uploadImage = async (
-  file: File
-): Promise<[upload: TTempFile | undefined, errorMsg: string]> => {
-  if (!file) return [undefined, 'No file selected. Please try again.'];
+const uploadImage = async (file: File): Promise<TTempFile | undefined> => {
+  if (!file) {
+    toast.error('No file selected. Please try again.');
+    return undefined;
+  }
 
   if (!file.type.startsWith('image/')) {
-    return [undefined, 'Invalid file type. Please try Again.'];
+    toast.error('Invalid file type. Please try Again.');
+    return undefined;
   }
 
-  const tempFile = await uploadFile(file);
-  if (!tempFile) {
-    return [undefined, 'Upload failed. Please try again.'];
-  }
-
-  return [tempFile, ''];
+  return await uploadFile(file);
 };
 
 type TUploadProgress = {

--- a/apps/server/src/routers/others/change-logo.ts
+++ b/apps/server/src/routers/others/change-logo.ts
@@ -16,6 +16,10 @@ const changeLogoRoute = protectedProcedure
   .mutation(async ({ ctx, input }) => {
     const settings = await getSettings();
 
+    if (input.fileId && !fileManager.temporaryFileHasMimeType(input.fileId, 'image/')) {
+      throw new Error('Invalid file type. Please try again.');
+    }
+
     if (settings.logoId) {
       await removeFile(settings.logoId);
       await updateSettings({ logoId: null });

--- a/apps/server/src/routers/others/change-logo.ts
+++ b/apps/server/src/routers/others/change-logo.ts
@@ -16,7 +16,10 @@ const changeLogoRoute = protectedProcedure
   .mutation(async ({ ctx, input }) => {
     const settings = await getSettings();
 
-    if (input.fileId && !fileManager.temporaryFileHasMimeType(input.fileId, 'image/')) {
+    if (
+      input.fileId &&
+      !fileManager.temporaryFileHasMimeType(input.fileId, 'image/')
+    ) {
       throw new Error('Invalid file type. Please try again.');
     }
 

--- a/apps/server/src/routers/users/change-avatar.ts
+++ b/apps/server/src/routers/users/change-avatar.ts
@@ -20,6 +20,10 @@ const changeAvatarRoute = protectedProcedure
   .mutation(async ({ ctx, input }) => {
     const user = await getUserById(ctx.userId);
 
+    if (input.fileId && !fileManager.temporaryFileHasMimeType(input.fileId, 'image/')) {
+      throw new Error('Invalid file type. Please try again.');
+    }
+
     invariant(user, {
       code: 'NOT_FOUND',
       message: 'User not found'

--- a/apps/server/src/routers/users/change-avatar.ts
+++ b/apps/server/src/routers/users/change-avatar.ts
@@ -20,7 +20,10 @@ const changeAvatarRoute = protectedProcedure
   .mutation(async ({ ctx, input }) => {
     const user = await getUserById(ctx.userId);
 
-    if (input.fileId && !fileManager.temporaryFileHasMimeType(input.fileId, 'image/')) {
+    if (
+      input.fileId &&
+      !fileManager.temporaryFileHasMimeType(input.fileId, 'image/')
+    ) {
       throw new Error('Invalid file type. Please try again.');
     }
 

--- a/apps/server/src/routers/users/change-banner.ts
+++ b/apps/server/src/routers/users/change-banner.ts
@@ -20,6 +20,10 @@ const changeBannerRoute = protectedProcedure
   .mutation(async ({ ctx, input }) => {
     const user = await getUserById(ctx.userId);
 
+    if (input.fileId && !fileManager.temporaryFileHasMimeType(input.fileId, 'image/')) {
+      throw new Error('Invalid file type. Please try again.');
+    }
+    
     invariant(user, {
       code: 'NOT_FOUND',
       message: 'User not found'

--- a/apps/server/src/routers/users/change-banner.ts
+++ b/apps/server/src/routers/users/change-banner.ts
@@ -20,10 +20,13 @@ const changeBannerRoute = protectedProcedure
   .mutation(async ({ ctx, input }) => {
     const user = await getUserById(ctx.userId);
 
-    if (input.fileId && !fileManager.temporaryFileHasMimeType(input.fileId, 'image/')) {
+    if (
+      input.fileId &&
+      !fileManager.temporaryFileHasMimeType(input.fileId, 'image/')
+    ) {
       throw new Error('Invalid file type. Please try again.');
     }
-    
+
     invariant(user, {
       code: 'NOT_FOUND',
       message: 'User not found'

--- a/apps/server/src/utils/file-manager.ts
+++ b/apps/server/src/utils/file-manager.ts
@@ -72,6 +72,11 @@ class TemporaryFileManager {
     return !!this.temporaryFiles.find((file) => file.id === id);
   };
 
+  public temporaryFileHasMimeType = (id: string, mimeTypePrefix: string): boolean => {
+    const bunFile = Bun.file(this.getTemporaryFile(id)?.path || '');
+    return (bunFile && bunFile.type.startsWith(mimeTypePrefix));
+  }
+
   public addTemporaryFile = async ({
     filePath,
     size,
@@ -152,6 +157,8 @@ class FileManager {
 
   public getTemporaryFile = this.tempFileManager.getTemporaryFile;
   public temporaryFileExists = this.tempFileManager.temporaryFileExists;
+
+  public temporaryFileHasMimeType = this.tempFileManager.temporaryFileHasMimeType;
 
   private handleStorageLimits = async (tempFile: TTempFile) => {
     const [settings, userStorage, serverStorage] = await Promise.all([

--- a/apps/server/src/utils/file-manager.ts
+++ b/apps/server/src/utils/file-manager.ts
@@ -72,10 +72,13 @@ class TemporaryFileManager {
     return !!this.temporaryFiles.find((file) => file.id === id);
   };
 
-  public temporaryFileHasMimeType = (id: string, mimeTypePrefix: string): boolean => {
+  public temporaryFileHasMimeType = (
+    id: string,
+    mimeTypePrefix: string
+  ): boolean => {
     const bunFile = Bun.file(this.getTemporaryFile(id)?.path || '');
-    return (bunFile && bunFile.type.startsWith(mimeTypePrefix));
-  }
+    return bunFile && bunFile.type.startsWith(mimeTypePrefix);
+  };
 
   public addTemporaryFile = async ({
     filePath,
@@ -158,7 +161,8 @@ class FileManager {
   public getTemporaryFile = this.tempFileManager.getTemporaryFile;
   public temporaryFileExists = this.tempFileManager.temporaryFileExists;
 
-  public temporaryFileHasMimeType = this.tempFileManager.temporaryFileHasMimeType;
+  public temporaryFileHasMimeType =
+    this.tempFileManager.temporaryFileHasMimeType;
 
   private handleStorageLimits = async (tempFile: TTempFile) => {
     const [settings, userStorage, serverStorage] = await Promise.all([


### PR DESCRIPTION
## Summary
Removes the ability for a user to upload non-image files to image only fields (logo, avatar, banner). Any file with a MIME type prefix other than "image" is blocked before the file upload has occurred.

Closes #669 

## Additional Comments
I have removed the toast.error("Upload failed. Please try again.") errors for logo, avatar, and banner since that is now provided by uploadFile as part of the #663 merge. Assuming I'm not looking at it wrong, we would have been seeing double toast messages on an upload error.