### PR TITLE
feat(678): Mute Hotkey not working + framework for adjustable hotkey configuration 

### DIFF
--- a/apps/client/src/components/hotkeys-controller/index.tsx
+++ b/apps/client/src/components/hotkeys-controller/index.tsx
@@ -6,39 +6,39 @@ import { memo, useEffect } from 'react';
 import { ShortcutRegistrar } from '../shortcut-registrar';
 
 const HotkeysController = memo(() => {
-  const pressedKeys = new Set<string>();
-
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.repeat) return;
-    pressedKeys.add(e.key);
-    ShortcutRegistrar.submit(pressedKeys, e);
-
-    setModifierKeysHeldMap({
-      Shift: e.shiftKey,
-      Control: e.ctrlKey,
-      Alt: e.altKey
-    });
-  };
-
-  const handleKeyUp = (e: KeyboardEvent) => {
-    pressedKeys.delete(e.key);
-
-    setModifierKeysHeldMap({
-      Shift: e.shiftKey,
-      Control: e.ctrlKey,
-      Alt: e.altKey
-    });
-  };
-
-  const handleBlur = () => {
-    setModifierKeysHeldMap({
-      Shift: false,
-      Control: false,
-      Alt: false
-    });
-  };
-
   useEffect(() => {
+    const pressedKeys = new Set<string>();
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.repeat) return;
+      pressedKeys.add(e.key.toLowerCase());
+      ShortcutRegistrar.submit(pressedKeys, e);
+
+      setModifierKeysHeldMap({
+        Shift: e.shiftKey,
+        Control: e.ctrlKey,
+        Alt: e.altKey
+      });
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      pressedKeys.delete(e.key.toLowerCase());
+
+      setModifierKeysHeldMap({
+        Shift: e.shiftKey,
+        Control: e.ctrlKey,
+        Alt: e.altKey
+      });
+    };
+
+    const handleBlur = () => {
+      pressedKeys.clear();
+      setModifierKeysHeldMap({
+        Shift: false,
+        Control: false,
+        Alt: false
+      });
+    };
+
     ShortcutRegistrar.register([], 'F4', togglePluginSlotDebug);
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('keyup', handleKeyUp);
@@ -50,7 +50,7 @@ const HotkeysController = memo(() => {
       window.removeEventListener('keyup', handleKeyUp);
       window.removeEventListener('blur', handleBlur);
     };
-  });
+  }, []);
   return null;
 });
 

--- a/apps/client/src/components/hotkeys-controller/index.tsx
+++ b/apps/client/src/components/hotkeys-controller/index.tsx
@@ -2,16 +2,16 @@ import {
   setModifierKeysHeldMap,
   togglePluginSlotDebug
 } from '@/features/app/actions';
-import { memo, useCallback, useEffect } from 'react';
+import { memo, useEffect } from 'react';
 import { ShortcutRegistrar } from '../shortcut-registrar';
 
 const HotkeysController = memo(() => {
   const pressedKeys = new Set<string>();
 
-  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+  const handleKeyDown = (e: KeyboardEvent) => {
     if (e.repeat) return;
     pressedKeys.add(e.key);
-    console.log('Pressed keys:', pressedKeys);    
+    console.log('Pressed keys:', pressedKeys);
     ShortcutRegistrar.submit(pressedKeys, e);
 
     setModifierKeysHeldMap({
@@ -19,25 +19,25 @@ const HotkeysController = memo(() => {
       Control: e.ctrlKey,
       Alt: e.altKey
     });
-  }, []);
+  };
 
-  const handleKeyUp = useCallback((e: KeyboardEvent) => {
-    pressedKeys.delete(e.key);    
-    
+  const handleKeyUp = (e: KeyboardEvent) => {
+    pressedKeys.delete(e.key);
+
     setModifierKeysHeldMap({
       Shift: e.shiftKey,
       Control: e.ctrlKey,
       Alt: e.altKey
     });
-  }, []);
+  };
 
-  const handleBlur = useCallback(() => {
+  const handleBlur = () => {
     setModifierKeysHeldMap({
       Shift: false,
       Control: false,
       Alt: false
     });
-  }, []);
+  };
 
   useEffect(() => {
     ShortcutRegistrar.register([], 'F4', togglePluginSlotDebug);

--- a/apps/client/src/components/hotkeys-controller/index.tsx
+++ b/apps/client/src/components/hotkeys-controller/index.tsx
@@ -11,7 +11,6 @@ const HotkeysController = memo(() => {
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.repeat) return;
     pressedKeys.add(e.key);
-    console.log('Pressed keys:', pressedKeys);
     ShortcutRegistrar.submit(pressedKeys, e);
 
     setModifierKeysHeldMap({

--- a/apps/client/src/components/hotkeys-controller/index.tsx
+++ b/apps/client/src/components/hotkeys-controller/index.tsx
@@ -3,16 +3,17 @@ import {
   togglePluginSlotDebug
 } from '@/features/app/actions';
 import { memo, useCallback, useEffect } from 'react';
+import { ShortcutRegistrar } from '../shortcut-registrar';
 
 const HotkeysController = memo(() => {
-  const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    if (e.key === 'F4') {
-      togglePluginSlotDebug();
-    }
+  const pressedKeys = new Set<string>();
 
-    if (e.key === 'Alt') {
-      e.preventDefault();
-    }
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.repeat) return;
+    pressedKeys.add(e.key);
+    console.log('Pressed keys:', pressedKeys);    
+    ShortcutRegistrar.submit(pressedKeys, e);
+
     setModifierKeysHeldMap({
       Shift: e.shiftKey,
       Control: e.ctrlKey,
@@ -21,6 +22,8 @@ const HotkeysController = memo(() => {
   }, []);
 
   const handleKeyUp = useCallback((e: KeyboardEvent) => {
+    pressedKeys.delete(e.key);    
+    
     setModifierKeysHeldMap({
       Shift: e.shiftKey,
       Control: e.ctrlKey,
@@ -37,16 +40,18 @@ const HotkeysController = memo(() => {
   }, []);
 
   useEffect(() => {
+    ShortcutRegistrar.register([], 'F4', togglePluginSlotDebug);
     window.addEventListener('keydown', handleKeyDown);
     window.addEventListener('keyup', handleKeyUp);
     window.addEventListener('blur', handleBlur);
 
     return () => {
+      ShortcutRegistrar.deregister([], 'F4');
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
       window.removeEventListener('blur', handleBlur);
     };
-  }, [handleKeyDown, handleKeyUp, handleBlur]);
+  });
   return null;
 });
 

--- a/apps/client/src/components/left-sidebar/user-control.tsx
+++ b/apps/client/src/components/left-sidebar/user-control.tsx
@@ -10,9 +10,9 @@ import { HeadphoneOff, Headphones, Mic, MicOff, Settings } from 'lucide-react';
 import { memo, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ServerScreen } from '../server-screens/screens';
+import { ShortcutRegistrar } from '../shortcut-registrar';
 import { UserAvatar } from '../user-avatar';
 import { UserPopover } from '../user-popover';
-import { ShortcutRegistrar } from '../shortcut-registrar';
 
 const UserControl = memo(() => {
   const { t } = useTranslation('sidebar');
@@ -27,7 +27,7 @@ const UserControl = memo(() => {
     return () => {
       ShortcutRegistrar.deregister(['control', 'shift'], 'm');
       ShortcutRegistrar.deregister(['control', 'shift'], 'd');
-    }
+    };
   });
 
   const handleSettingsClick = useCallback(() => {

--- a/apps/client/src/components/left-sidebar/user-control.tsx
+++ b/apps/client/src/components/left-sidebar/user-control.tsx
@@ -21,14 +21,23 @@ const UserControl = memo(() => {
   const { ownVoiceState, toggleMic, toggleSound } = useVoice();
   const channelCan = useChannelCan(currentVoiceChannelId);
 
+  const handleToggleMicShortcut = useCallback(() => {
+    if (!!currentVoiceChannelId && !channelCan(ChannelPermission.SPEAK)) return;
+    toggleMic();
+  }, [currentVoiceChannelId, toggleMic, channelCan]);
+
   useEffect(() => {
-    ShortcutRegistrar.register(['control', 'shift'], 'm', toggleMic);
+    ShortcutRegistrar.register(
+      ['control', 'shift'],
+      'm',
+      handleToggleMicShortcut
+    );
     ShortcutRegistrar.register(['control', 'shift'], 'd', toggleSound);
     return () => {
       ShortcutRegistrar.deregister(['control', 'shift'], 'm');
       ShortcutRegistrar.deregister(['control', 'shift'], 'd');
     };
-  });
+  }, [handleToggleMicShortcut, toggleSound]);
 
   const handleSettingsClick = useCallback(() => {
     openServerScreen(ServerScreen.USER_SETTINGS);

--- a/apps/client/src/components/left-sidebar/user-control.tsx
+++ b/apps/client/src/components/left-sidebar/user-control.tsx
@@ -7,11 +7,12 @@ import { cn } from '@/lib/utils';
 import { ChannelPermission } from '@sharkord/shared';
 import { Button } from '@sharkord/ui';
 import { HeadphoneOff, Headphones, Mic, MicOff, Settings } from 'lucide-react';
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ServerScreen } from '../server-screens/screens';
 import { UserAvatar } from '../user-avatar';
 import { UserPopover } from '../user-popover';
+import { ShortcutRegistrar } from '../shortcut-registrar';
 
 const UserControl = memo(() => {
   const { t } = useTranslation('sidebar');
@@ -19,6 +20,15 @@ const UserControl = memo(() => {
   const currentVoiceChannelId = useCurrentVoiceChannelId();
   const { ownVoiceState, toggleMic, toggleSound } = useVoice();
   const channelCan = useChannelCan(currentVoiceChannelId);
+
+  useEffect(() => {
+    ShortcutRegistrar.register(['control', 'shift'], 'm', toggleMic);
+    ShortcutRegistrar.register(['control', 'shift'], 'd', toggleSound);
+    return () => {
+      ShortcutRegistrar.deregister(['control', 'shift'], 'm');
+      ShortcutRegistrar.deregister(['control', 'shift'], 'd');
+    }
+  });
 
   const handleSettingsClick = useCallback(() => {
     openServerScreen(ServerScreen.USER_SETTINGS);

--- a/apps/client/src/components/shortcut-registrar/index.tsx
+++ b/apps/client/src/components/shortcut-registrar/index.tsx
@@ -1,8 +1,5 @@
 type TModifier = 'shift' | 'control' | 'alt' | 'meta';
-const ModifierArray: TModifier[] = ['shift', 'control', 'alt', 'meta'];
-type THotkeyEntry = {
-  modifiers: TModifier[];
-  key: string;
+type TAction = {
   action: () => void;
 };
 
@@ -11,20 +8,24 @@ const normalizeKey = (key: string) => replaceMetaWithControl(key.toLowerCase());
 const replaceMetaWithControl = (key: string) =>
   key === 'meta' ? 'control' : key;
 
+const getShortcutHash = (modifiers: string[], key: string) => {
+  const sortedKeys = [...modifiers, key].map(normalizeKey).sort();
+  return `${sortedKeys.join('+')}`;
+};
+
 const getShortcutHashFromSet = (keys: Set<string>) => {
   const sortedKeys = [...keys].map(normalizeKey).sort();
   return `${sortedKeys.join('+')}`;
 };
 
-const getShortcutHash = (modifiers: string[], key: string) => {
-  const normalizedModifiers = modifiers.map(normalizeKey);
-  const normalizedKey = normalizeKey(key);
-  const sortedKeys = [...normalizedModifiers, normalizedKey].sort();
-  return `${sortedKeys.join('+')}`;
+const getShortcutHashFromString = (shortcut: string) => {
+  const splitShortcut = shortcut.split('+').map((part) => part.trim());
+  const normalizedShortcut = splitShortcut.map(normalizeKey).sort().join('+');
+  return normalizedShortcut;
 };
 
 class THotkeyShortcutRegistrar {
-  private hotkeyShortcuts = new Map<string, THotkeyEntry>();
+  private hotkeyShortcuts = new Map<string, TAction>();
 
   public has = (shortcutHash: string) => {
     return this.hotkeyShortcuts.has(shortcutHash);
@@ -52,16 +53,12 @@ class THotkeyShortcutRegistrar {
     action: () => void
   ) => {
     const shortcutHash = getShortcutHash(modifiers, key);
-    const entry: THotkeyEntry = {
-      modifiers,
-      key,
-      action
-    };
+    const entry: TAction = { action };
     this.set(shortcutHash, entry);
   };
 
   public registerBatch = (
-    entries: { modifiers: TModifier[]; key: string; action: () => void }[]
+    ...entries: { modifiers: TModifier[]; key: string; action: () => void }[]
   ) => {
     entries.forEach(({ modifiers, key, action }) => {
       this.register(modifiers, key, action);
@@ -69,19 +66,9 @@ class THotkeyShortcutRegistrar {
   };
 
   public registerCustom = (shortcut: string, action: () => void) => {
-    const splitShortcut = shortcut.split('+').map((part) => part.trim());
-    const normalizedShortcut = splitShortcut.map(normalizeKey).sort().join('+');
-    const entry: THotkeyEntry = {
-      modifiers: splitShortcut.filter((part) =>
-        ModifierArray.includes(part as TModifier)
-      ) as TModifier[],
-      key:
-        splitShortcut.find(
-          (part) => !ModifierArray.includes(part as TModifier)
-        ) || '',
-      action
-    };
-    this.set(normalizedShortcut, entry);
+    const shortcutHash = getShortcutHashFromString(shortcut);
+    const entry: TAction = { action };
+    this.set(shortcutHash, entry);
   };
 
   public deregister = (modifiers: TModifier[], key: string) => {
@@ -89,11 +76,24 @@ class THotkeyShortcutRegistrar {
     this.delete(shortcutHash);
   };
 
+  public deregisterCustom = (shortcut: string) => {
+    const shortcutHash = getShortcutHashFromString(shortcut);
+    this.delete(shortcutHash);
+  };
+
+  public deregisterBatch = (
+    ...entries: { modifiers: TModifier[]; key: string }[]
+  ) => {
+    entries.forEach(({ modifiers, key }) => {
+      this.deregister(modifiers, key);
+    });
+  };
+
   private get = (shortcutHash: string) => {
     return this.hotkeyShortcuts.get(shortcutHash);
   };
 
-  private set = (shortcutHash: string, entry: THotkeyEntry) => {
+  private set = (shortcutHash: string, entry: TAction) => {
     this.hotkeyShortcuts.set(shortcutHash, entry);
   };
 

--- a/apps/client/src/components/shortcut-registrar/index.tsx
+++ b/apps/client/src/components/shortcut-registrar/index.tsx
@@ -8,26 +8,27 @@ type THotkeyEntry = {
 
 const normalizeKey = (key: string) => replaceMetaWithControl(key.toLowerCase());
 
-const replaceMetaWithControl = (key: string) => key === 'meta' ? 'control' : key;
+const replaceMetaWithControl = (key: string) =>
+  key === 'meta' ? 'control' : key;
 
 const getShortcutHashFromSet = (keys: Set<string>) => {
   const sortedKeys = [...keys].map(normalizeKey).sort();
   return `${sortedKeys.join('+')}`;
-}
+};
 
 const getShortcutHash = (modifiers: string[], key: string) => {
   const normalizedModifiers = modifiers.map(normalizeKey);
   const normalizedKey = normalizeKey(key);
   const sortedKeys = [...normalizedModifiers, normalizedKey].sort();
   return `${sortedKeys.join('+')}`;
-}
+};
 
 class THotkeyShortcutRegistrar {
   private hotkeyShortcuts = new Map<string, THotkeyEntry>();
 
   public has = (shortcutHash: string) => {
     return this.hotkeyShortcuts.has(shortcutHash);
-  }
+  };
 
   public submit = (pressedKeys: Set<string>, e: KeyboardEvent) => {
     const hash = getShortcutHashFromSet(pressedKeys);
@@ -37,7 +38,7 @@ class THotkeyShortcutRegistrar {
     } else if (hash === 'alt') {
       e.preventDefault();
     }
-  }
+  };
 
   public invoke = (shortcutHash: string) => {
     if (this.has(shortcutHash)) {
@@ -45,7 +46,11 @@ class THotkeyShortcutRegistrar {
     }
   };
 
-  public register = (modifiers: TModifier[], key: string, action: () => void) => {
+  public register = (
+    modifiers: TModifier[],
+    key: string,
+    action: () => void
+  ) => {
     const shortcutHash = getShortcutHash(modifiers, key);
     const entry: THotkeyEntry = {
       modifiers,
@@ -53,41 +58,48 @@ class THotkeyShortcutRegistrar {
       action
     };
     this.set(shortcutHash, entry);
-  }
+  };
 
-  public registerBatch = (entries: { modifiers: TModifier[]; key: string; action: () => void }[]) => {
+  public registerBatch = (
+    entries: { modifiers: TModifier[]; key: string; action: () => void }[]
+  ) => {
     entries.forEach(({ modifiers, key, action }) => {
       this.register(modifiers, key, action);
     });
-  }
+  };
 
   public registerCustom = (shortcut: string, action: () => void) => {
-    const splitShortcut = shortcut.split('+').map(part => part.trim());
+    const splitShortcut = shortcut.split('+').map((part) => part.trim());
     const normalizedShortcut = splitShortcut.map(normalizeKey).sort().join('+');
     const entry: THotkeyEntry = {
-      modifiers: splitShortcut.filter(part => ModifierArray.includes(part as TModifier)) as TModifier[],
-      key: splitShortcut.find(part => !ModifierArray.includes(part as TModifier)) || '',
+      modifiers: splitShortcut.filter((part) =>
+        ModifierArray.includes(part as TModifier)
+      ) as TModifier[],
+      key:
+        splitShortcut.find(
+          (part) => !ModifierArray.includes(part as TModifier)
+        ) || '',
       action
     };
     this.set(normalizedShortcut, entry);
-  }
+  };
 
   public deregister = (modifiers: TModifier[], key: string) => {
     const shortcutHash = getShortcutHash(modifiers, key);
     this.delete(shortcutHash);
-  }
+  };
 
   private get = (shortcutHash: string) => {
     return this.hotkeyShortcuts.get(shortcutHash);
-  }
+  };
 
   private set = (shortcutHash: string, entry: THotkeyEntry) => {
     this.hotkeyShortcuts.set(shortcutHash, entry);
-  }
+  };
 
   private delete = (shortcutHash: string) => {
     this.hotkeyShortcuts.delete(shortcutHash);
-  }
+  };
 }
 
 const ShortcutRegistrar = new THotkeyShortcutRegistrar();

--- a/apps/client/src/components/shortcut-registrar/index.tsx
+++ b/apps/client/src/components/shortcut-registrar/index.tsx
@@ -8,23 +8,27 @@ const normalizeKey = (key: string) => replaceMetaWithControl(key.toLowerCase());
 const replaceMetaWithControl = (key: string) =>
   key === 'meta' ? 'control' : key;
 
+const getNormalizedShortcutHash = (keys: string[]) => {
+  const sortedKeys = [...new Set(keys.map(normalizeKey))].sort();
+  return sortedKeys.join('+');
+};
+
 const getShortcutHash = (modifiers: string[], key: string) => {
   const sortedKeys = [...modifiers, key].map(normalizeKey).sort();
-  return `${sortedKeys.join('+')}`;
+  return getNormalizedShortcutHash(sortedKeys);
 };
 
 const getShortcutHashFromSet = (keys: Set<string>) => {
   const sortedKeys = [...keys].map(normalizeKey).sort();
-  return `${sortedKeys.join('+')}`;
+  return getNormalizedShortcutHash(sortedKeys);
 };
 
 const getShortcutHashFromString = (shortcut: string) => {
   const splitShortcut = shortcut.split('+').map((part) => part.trim());
-  const normalizedShortcut = splitShortcut.map(normalizeKey).sort().join('+');
-  return normalizedShortcut;
+  return getNormalizedShortcutHash(splitShortcut);
 };
 
-class THotkeyShortcutRegistrar {
+class HotkeyShortcutRegistrar {
   private hotkeyShortcuts = new Map<string, TAction>();
 
   public has = (shortcutHash: string) => {
@@ -102,6 +106,6 @@ class THotkeyShortcutRegistrar {
   };
 }
 
-const ShortcutRegistrar = new THotkeyShortcutRegistrar();
+const ShortcutRegistrar = new HotkeyShortcutRegistrar();
 
 export { ShortcutRegistrar };

--- a/apps/client/src/components/shortcut-registrar/index.tsx
+++ b/apps/client/src/components/shortcut-registrar/index.tsx
@@ -1,0 +1,95 @@
+type TModifier = 'shift' | 'control' | 'alt' | 'meta';
+const ModifierArray: TModifier[] = ['shift', 'control', 'alt', 'meta'];
+type THotkeyEntry = {
+  modifiers: TModifier[];
+  key: string;
+  action: () => void;
+};
+
+const normalizeKey = (key: string) => replaceMetaWithControl(key.toLowerCase());
+
+const replaceMetaWithControl = (key: string) => key === 'meta' ? 'control' : key;
+
+const getShortcutHashFromSet = (keys: Set<string>) => {
+  const sortedKeys = [...keys].map(normalizeKey).sort();
+  return `${sortedKeys.join('+')}`;
+}
+
+const getShortcutHash = (modifiers: string[], key: string) => {
+  const normalizedModifiers = modifiers.map(normalizeKey);
+  const normalizedKey = normalizeKey(key);
+  const sortedKeys = [...normalizedModifiers, normalizedKey].sort();
+  return `${sortedKeys.join('+')}`;
+}
+
+class THotkeyShortcutRegistrar {
+  private hotkeyShortcuts = new Map<string, THotkeyEntry>();
+
+  public has = (shortcutHash: string) => {
+    return this.hotkeyShortcuts.has(shortcutHash);
+  }
+
+  public submit = (pressedKeys: Set<string>, e: KeyboardEvent) => {
+    const hash = getShortcutHashFromSet(pressedKeys);
+    if (this.has(hash)) {
+      e.preventDefault();
+      this.invoke(hash);
+    } else if (hash === 'alt') {
+      e.preventDefault();
+    }
+  }
+
+  public invoke = (shortcutHash: string) => {
+    if (this.has(shortcutHash)) {
+      this.get(shortcutHash)?.action();
+    }
+  };
+
+  public register = (modifiers: TModifier[], key: string, action: () => void) => {
+    const shortcutHash = getShortcutHash(modifiers, key);
+    const entry: THotkeyEntry = {
+      modifiers,
+      key,
+      action
+    };
+    this.set(shortcutHash, entry);
+  }
+
+  public registerBatch = (entries: { modifiers: TModifier[]; key: string; action: () => void }[]) => {
+    entries.forEach(({ modifiers, key, action }) => {
+      this.register(modifiers, key, action);
+    });
+  }
+
+  public registerCustom = (shortcut: string, action: () => void) => {
+    const splitShortcut = shortcut.split('+').map(part => part.trim());
+    const normalizedShortcut = splitShortcut.map(normalizeKey).sort().join('+');
+    const entry: THotkeyEntry = {
+      modifiers: splitShortcut.filter(part => ModifierArray.includes(part as TModifier)) as TModifier[],
+      key: splitShortcut.find(part => !ModifierArray.includes(part as TModifier)) || '',
+      action
+    };
+    this.set(normalizedShortcut, entry);
+  }
+
+  public deregister = (modifiers: TModifier[], key: string) => {
+    const shortcutHash = getShortcutHash(modifiers, key);
+    this.delete(shortcutHash);
+  }
+
+  private get = (shortcutHash: string) => {
+    return this.hotkeyShortcuts.get(shortcutHash);
+  }
+
+  private set = (shortcutHash: string, entry: THotkeyEntry) => {
+    this.hotkeyShortcuts.set(shortcutHash, entry);
+  }
+
+  private delete = (shortcutHash: string) => {
+    this.hotkeyShortcuts.delete(shortcutHash);
+  }
+}
+
+const ShortcutRegistrar = new THotkeyShortcutRegistrar();
+
+export { ShortcutRegistrar };

--- a/apps/client/src/components/top-bar/server-search.tsx
+++ b/apps/client/src/components/top-bar/server-search.tsx
@@ -1,6 +1,6 @@
 import { openDialog } from '@/features/dialogs/actions';
 import { Search } from 'lucide-react';
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Dialog } from '../dialogs/dialogs';
 import { ShortcutRegistrar } from '../shortcut-registrar';
@@ -11,7 +11,12 @@ const ServerSearch = memo(() => {
     openDialog(Dialog.SEARCH);
   }, []);
 
-  ShortcutRegistrar.register(['control'], 'k', openSearchDialog);
+  useEffect(() => {
+    ShortcutRegistrar.register(['control'], 'k', openSearchDialog);
+    return () => {
+      ShortcutRegistrar.deregister(['control'], 'k');
+    };
+  }, [openSearchDialog]);
 
   return (
     <button

--- a/apps/client/src/components/top-bar/server-search.tsx
+++ b/apps/client/src/components/top-bar/server-search.tsx
@@ -1,8 +1,9 @@
 import { openDialog } from '@/features/dialogs/actions';
 import { Search } from 'lucide-react';
-import { memo, useCallback, useEffect } from 'react';
+import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Dialog } from '../dialogs/dialogs';
+import { ShortcutRegistrar } from '../shortcut-registrar';
 
 const ServerSearch = memo(() => {
   const { t } = useTranslation('topbar');
@@ -10,18 +11,7 @@ const ServerSearch = memo(() => {
     openDialog(Dialog.SEARCH);
   }, []);
 
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
-        event.preventDefault();
-        openSearchDialog();
-      }
-    };
-
-    window.addEventListener('keydown', onKeyDown);
-
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [openSearchDialog]);
+  ShortcutRegistrar.register(['control'], 'k', openSearchDialog);
 
   return (
     <button


### PR DESCRIPTION
## Summary
This PR adds a new client-side structure called a ShortcutRegistrar. This was an offshoot of the HotkeysController, aimed at providing function callback behavior for dynamically registered keyboard shortcuts. No more writing keyDown listeners. In the spirit of the original issue, I've also implemented shortcuts for Mute and Deafen, as per their description in the sidebar.json.
Closes #678 

## Additional Context
I've left the "setModifierKeysHeldMap" behavior intact to allow for more dynamic application of the modifier keys in cases where a shortcut is not explicitly needed (e.g. shift for super-delete). 

While the framework is in place and preliminary function seems promising, I didn't feel like it was my place to decide what actions do and don't warrant user-configurable shortcut keys. As such, I have not implemented anything past the framework for registering those custom shortcuts. If desired I can throw something together, or we can put that up for discussion in it's own Issue.