### PR TITLE
fix(703): don't let too many files overflow chat input max height

### DIFF
--- a/apps/client/src/components/channel-view/text/chat-input-divider.tsx
+++ b/apps/client/src/components/channel-view/text/chat-input-divider.tsx
@@ -44,7 +44,7 @@ const ChatInputDivider = ({
       const startHeightPx = getHeight(composeEl);
 
       const maxPx = (MAX_VH / 100) * window.innerHeight;
-      const minPx = measureMinHeight(composeEl);
+      const minPx = Math.min(measureMinHeight(composeEl), maxPx);
 
       composeEl.style.maxHeight = '';
       composeEl.style.height = `${startHeightPx}px`;
@@ -95,8 +95,17 @@ const ChatInputDivider = ({
             composeEl.dataset.pendingUnpinOnSend = 'true';
           } else {
             // single line or empty -- reset to auto-grow mode
+            const defaultMaxPx =
+              (defaultMaxHeightVh / 100) * window.innerHeight;
+
+            // take the larger of our measured height and default max, clamped to MAX_VH
+            const resetMaxPx = Math.min(Math.max(defaultMaxPx, minPx), maxPx);
+            const resetMaxVh = Math.round(
+              (resetMaxPx / window.innerHeight) * 100
+            );
+
             composeEl.style.height = '';
-            composeEl.style.maxHeight = `${defaultMaxHeightVh}vh`;
+            composeEl.style.maxHeight = `${resetMaxVh}vh`;
 
             delete composeEl.dataset.pendingUnpinOnSend;
           }

--- a/apps/client/src/components/message-compose/hooks.ts
+++ b/apps/client/src/components/message-compose/hooks.ts
@@ -3,7 +3,11 @@ import {
   LocalStorageKey
 } from '@/helpers/storage';
 import { useEffect, useLayoutEffect, useRef } from 'react';
-import { getHeight, measureMinHeight } from '../channel-view/text/helpers';
+import {
+  getHeight,
+  MAX_VH,
+  measureMinHeight
+} from '../channel-view/text/helpers';
 
 type TUseFileAwareHeightParams = {
   containerRef: React.RefObject<HTMLDivElement | null>;
@@ -45,35 +49,46 @@ const useFileAwareHeight = ({
   useEffect(() => {
     const el = containerRef.current;
 
-    if (!el?.style.height) return;
+    if (!el) return;
 
     const currentPx = getHeight(el);
+    const maxPx = (MAX_VH / 100) * window.innerHeight;
 
     if (displayItems.length > 0) {
-      // measure the natural height with files present
+      // measure the natural height with files present -- clear both height and
+      // maxHeight so the default max doesn't artificially cap the measurement
       const savedHeight = el.style.height;
+      const savedMaxHeight = el.style.maxHeight;
 
       el.style.height = '';
+      el.style.maxHeight = '';
 
       const naturalPx = getHeight(el);
 
       el.style.height = savedHeight;
+      el.style.maxHeight = savedMaxHeight;
 
-      if (naturalPx > currentPx) {
-        if (userPinnedHeightRef.current === null) {
-          userPinnedHeightRef.current = currentPx;
-        }
-
-        el.style.height = `${naturalPx}px`;
+      const clampedNaturalPx = Math.min(naturalPx, maxPx);
+      if (el.style.height) {
+        userPinnedHeightRef.current ||= currentPx;
       }
-    } else if (userPinnedHeightRef.current !== null) {
+
+      if (clampedNaturalPx > currentPx) {
+        el.style.height = '';
+        el.style.maxHeight = `${clampedNaturalPx}px`;
+      }
+    } else {
       const minPx = measureMinHeight(el);
 
-      el.style.height = `${Math.max(userPinnedHeightRef.current, minPx)}px`;
+      if (userPinnedHeightRef.current) {
+        el.style.height = `${Math.max(userPinnedHeightRef.current, minPx)}px`;
+      } else {
+        el.style.maxHeight = `${inputDefaultMaxHeightVh}vh`;
+      }
 
       userPinnedHeightRef.current = null;
     }
-  }, [displayItems, containerRef]);
+  }, [displayItems, containerRef, inputDefaultMaxHeightVh]);
 };
 
 export { useFileAwareHeight };


### PR DESCRIPTION
## Summary

In this PR we deal better with resizing the `message-compose` component when there are many files on a small screen. 

Closes #703

## Additional Context

This addresses two issues...

#### 1) Files causing container to grow beyond default max height

When we add so many files that it would make `message-compose` grow taller than the default max height of the component, the measurement of the "natural height" was inadvertently being clamped to that max height, resulting in jumpy resizing behavior.

To address this, we unset `max-height` before we measure, and restore it afterwards.

https://github.com/user-attachments/assets/e29239b3-a22a-4e80-8941-ba26d64e0d37
> When files cause the container to grow beyond the default max height, drag-drop resizing still works smoothly

#### 2) Even more files causing container to grow beyond viewport height

With even more files, they could make the container be taller than the entire viewport, making some content unreachable.

To address this, we clamp the container height to an absolute max height of `80vh`, and then restore the previous height (if you had dragged to an explicit height), or else the max height (if you had not) when the files are either removed, or sent with the message.
