### PR TITLE
fix(#771): Fixed no background on Avatars

### DIFF
--- a/apps/client/src/components/user-avatar/index.tsx
+++ b/apps/client/src/components/user-avatar/index.tsx
@@ -31,8 +31,8 @@ const UserAvatar = memo(
     if (!user) return null;
 
     const content = (
-      <div className="relative w-fit h-fit" onClick={onClick}>
-        <Avatar className={cn('h-8 w-8', className)}>
+      <div className="relative size-fit" onClick={onClick}>
+        <Avatar className={cn('size-8 bg-muted', className)}>
           <AvatarImage src={getFileUrl(user.avatar)} key={user.avatarId} />
           <AvatarFallback className="bg-muted text-xs">
             {getInitialsFromName(getRenderedUsername(user))}


### PR DESCRIPTION
## Summary

Adds background to user avatar in case of PNG images. 

Closes #711 

## Additional Context

Used same as fallback `bg-muted` and changed some css styling as well as having both height and with the same is equal to the `size` from tailwind.

<details>
<summary>Example new</summary>

<img width="601" height="584" alt="image" src="https://github.com/user-attachments/assets/c8bac7c7-4d9c-4883-a16c-85bac0f341d6" />

</details>

<details>
<summary>Example old</summary>

<img width="569" height="554" alt="image" src="https://github.com/user-attachments/assets/fb45325a-d9b1-46a5-bbfe-92ac82debf12" />

</details>