### PR TITLE
fix(713): update storage quota checks in getExceedingOldFiles function

### DIFF
--- a/apps/server/src/db/queries/files.ts
+++ b/apps/server/src/db/queries/files.ts
@@ -6,10 +6,10 @@ import { files, messageFiles } from '../schema';
 import { getSettings } from './server';
 
 const getExceedingOldFiles = async (newFileSize: number) => {
-  const { storageUploadMaxFileSize } = await getSettings();
+  const { storageQuota, storageUploadMaxFileSize } = await getSettings();
 
   if (newFileSize > storageUploadMaxFileSize) {
-    throw new Error('File size exceeds total server storage quota');
+    throw new Error('File size exceeds the maximum allowed file size');
   }
 
   const currentUsage = await db
@@ -20,8 +20,7 @@ const getExceedingOldFiles = async (newFileSize: number) => {
     .get();
 
   const currentTotalSize = Number(currentUsage?.totalSize ?? 0);
-  const wouldExceedBy =
-    currentTotalSize + newFileSize - storageUploadMaxFileSize;
+  const wouldExceedBy = currentTotalSize + newFileSize - storageQuota;
 
   if (wouldExceedBy <= 0) {
     return [];


### PR DESCRIPTION
## Fix: use `storageQuota` to compute storage overflow in `getExceedingOldFiles`

Closes #713 

## What changed

In `apps/server/src/db/queries/files.ts`, `getExceedingOldFiles` now calculates how much space must be freed against `storageQuota` (total server cap) instead of `storageUploadMaxFileSize` (per-file cap). The per-file pre-check is kept and its error message is corrected.

### Before

```ts
const { storageUploadMaxFileSize } = await getSettings();

if (newFileSize > storageUploadMaxFileSize) {
  throw new Error('File size exceeds total server storage quota');
}

const currentTotalSize = Number(currentUsage?.totalSize ?? 0);
const wouldExceedBy =
  currentTotalSize + newFileSize - storageUploadMaxFileSize;
```

### After

```ts
const { storageQuota, storageUploadMaxFileSize } = await getSettings();

if (newFileSize > storageUploadMaxFileSize) {
  throw new Error('File size exceeds the maximum allowed file size');
}

const currentTotalSize = Number(currentUsage?.totalSize ?? 0);
const wouldExceedBy = currentTotalSize + newFileSize - storageQuota;
```

## Why

`getExceedingOldFiles` is invoked from `file-manager.ts` only after the outer check `newServerStorage > storageQuota` has already determined that the **aggregate** server quota would be exceeded. Its job is to decide how many old files to evict to bring the aggregate back under that quota, so the math must reference `storageQuota`, not the per-file limit.

The two responsibilities are now cleanly separated:

- `storageUploadMaxFileSize` is used **only** for the per-file pre-check (rejecting an upload that would be invalid even with unlimited space).
- `storageQuota` is used for the aggregate overflow calculation that drives which files get pruned.

The pre-check error message is also corrected: it previously claimed "total server storage quota" while the condition actually compares against the per-file limit.

## Effect on `DELETE_OLD_FILES`

With the previous formula, `wouldExceedBy` was computed against `storageUploadMaxFileSize` instead of `storageQuota`, producing an incorrect amount of space to free:

- When `storageUploadMaxFileSize` < `storageQuota` (typical config): `wouldExceedBy` was inflated, causing far more files to be deleted than necessary.
- When `storageUploadMaxFileSize` > `storageQuota` (inverted config): `wouldExceedBy` was negative or zero, so the function returned `[]` and no files were ever pruned — the server silently exceeded its quota.

After this fix, `DELETE_OLD_FILES` correctly evicts only the oldest files needed to bring aggregate usage back within `storageQuota`.

## Risk / compatibility

- No schema changes, no settings changes, no API surface changes.
- The only observable behavior change occurs when `DELETE_OLD_FILES` is configured: it now actually deletes files (which is the intended behavior).
- The error message change is user-facing only when an upload exceeds `storageUploadMaxFileSize`; the new wording matches what the check actually verifies.

## Suggested follow-ups (out of scope)

- Add a unit test for `getExceedingOldFiles` covering the case `storageUploadMaxFileSize < storageQuota` to prevent regressions.