### PR TITLE
fix: post-sanitization guard checks original input instead of sanitized content

### DIFF
--- a/apps/server/src/routers/messages/edit-message.ts
+++ b/apps/server/src/routers/messages/edit-message.ts
@@ -68,7 +68,7 @@ const editMessageRoute = rateLimitedProcedure(protectedProcedure, {
 
     const sanitizedContent = sanitizeMessageHtml(input.content);
 
-    invariant(!isEmptyMessage(input.content), {
+    invariant(!isEmptyMessage(sanitizedContent), {
       code: 'BAD_REQUEST',
       message:
         'Your message only contained unsupported or removed content, so there was nothing to send.'

--- a/apps/server/src/routers/messages/send-message.ts
+++ b/apps/server/src/routers/messages/send-message.ts
@@ -134,7 +134,7 @@ const sendMessageRoute = rateLimitedProcedure(protectedProcedure, {
 
     let targetContent = sanitizeMessageHtml(input.content);
 
-    invariant(!isEmptyMessage(input.content) || limitedFiles.length != 0, {
+    invariant(!isEmptyMessage(targetContent) || limitedFiles.length != 0, {
       code: 'BAD_REQUEST',
       message:
         'Your message only contained unsupported or removed content, so there was nothing to send.'


### PR DESCRIPTION
Small logic bug: the second `invariant` in both `send-message.ts` and `edit-message.ts`
reads `input.content` instead of the sanitized variable, so content that sanitizes
to an empty string (e.g. `<script>`) bypasses the guard and gets stored as `""`.

No real attack surface — requires authentication + SEND_MESSAGES permission, and the
XSS payload itself is never stored. Pure data integrity issue.

Not worth a separate issue given the triviality of the fix.

**Changed:** `isEmptyMessage(input.content)` → `isEmptyMessage(targetContent / sanitizedContent)` in both files.  