### PR TITLE
fix(722): add rate limiting to unprotected high-cost endpoints

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -41,6 +41,34 @@ const zConfig = z.object({
     search: z.object({
       maxRequests: z.coerce.number().int().positive(),
       windowMs: z.coerce.number().int().positive()
+    }),
+    signalTyping: z.object({
+      maxRequests: z.coerce.number().int().positive(),
+      windowMs: z.coerce.number().int().positive()
+    }),
+    getMessages: z.object({
+      maxRequests: z.coerce.number().int().positive(),
+      windowMs: z.coerce.number().int().positive()
+    }),
+    markAsRead: z.object({
+      maxRequests: z.coerce.number().int().positive(),
+      windowMs: z.coerce.number().int().positive()
+    }),
+    toggleMessageReaction: z.object({
+      maxRequests: z.coerce.number().int().positive(),
+      windowMs: z.coerce.number().int().positive()
+    }),
+    addEmoji: z.object({
+      maxRequests: z.coerce.number().int().positive(),
+      windowMs: z.coerce.number().int().positive()
+    }),
+    openDirectMessage: z.object({
+      maxRequests: z.coerce.number().int().positive(),
+      windowMs: z.coerce.number().int().positive()
+    }),
+    handshake: z.object({
+      maxRequests: z.coerce.number().int().positive(),
+      windowMs: z.coerce.number().int().positive()
     })
   })
 });
@@ -73,6 +101,34 @@ const defaultConfig: TConfig = {
     },
     search: {
       maxRequests: 15,
+      windowMs: 60_000
+    },
+    signalTyping: {
+      maxRequests: 40,
+      windowMs: 5_000
+    },
+    getMessages: {
+      maxRequests: 60,
+      windowMs: 10_000
+    },
+    markAsRead: {
+      maxRequests: 60,
+      windowMs: 10_000
+    },
+    toggleMessageReaction: {
+      maxRequests: 60,
+      windowMs: 10_000
+    },
+    addEmoji: {
+      maxRequests: 10,
+      windowMs: 60_000
+    },
+    openDirectMessage: {
+      maxRequests: 10,
+      windowMs: 60_000
+    },
+    handshake: {
+      maxRequests: 10,
       windowMs: 60_000
     }
   }

--- a/apps/server/src/routers/channels/mark-as-read.ts
+++ b/apps/server/src/routers/channels/mark-as-read.ts
@@ -1,12 +1,17 @@
 import { type TMessage } from '@sharkord/shared';
 import { and, desc, eq, isNull } from 'drizzle-orm';
 import { z } from 'zod';
+import { config } from '../../config';
 import { db } from '../../db';
 import { assertDmChannel } from '../../db/queries/dms';
 import { channelReadStates, messages } from '../../db/schema';
-import { protectedProcedure } from '../../utils/trpc';
+import { protectedProcedure, rateLimitedProcedure } from '../../utils/trpc';
 
-const markAsReadRoute = protectedProcedure
+const markAsReadRoute = rateLimitedProcedure(protectedProcedure, {
+  maxRequests: config.rateLimiters.markAsRead.maxRequests,
+  windowMs: config.rateLimiters.markAsRead.windowMs,
+  logLabel: 'markAsRead'
+})
   .input(
     z.object({
       channelId: z.number()

--- a/apps/server/src/routers/dms/open-direct-message.ts
+++ b/apps/server/src/routers/dms/open-direct-message.ts
@@ -1,15 +1,20 @@
 import { ChannelType, ServerEvents } from '@sharkord/shared';
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
+import { config } from '../../config';
 import { db } from '../../db';
 import { publishChannelPermissions } from '../../db/publishers';
 import { getDirectMessageChannel, normalizePair } from '../../db/queries/dms';
 import { getSettings } from '../../db/queries/server';
 import { channels, directMessages, users } from '../../db/schema';
 import { invariant } from '../../utils/invariant';
-import { protectedProcedure } from '../../utils/trpc';
+import { protectedProcedure, rateLimitedProcedure } from '../../utils/trpc';
 
-const openDirectMessageRoute = protectedProcedure
+const openDirectMessageRoute = rateLimitedProcedure(protectedProcedure, {
+  maxRequests: config.rateLimiters.openDirectMessage.maxRequests,
+  windowMs: config.rateLimiters.openDirectMessage.windowMs,
+  logLabel: 'openDirectMessage'
+})
   .input(
     z.object({
       userId: z.number()

--- a/apps/server/src/routers/emojis/add-emoji.ts
+++ b/apps/server/src/routers/emojis/add-emoji.ts
@@ -1,14 +1,19 @@
 import { ActivityLogType, FileSaveType, Permission } from '@sharkord/shared';
 import { z } from 'zod';
+import { config } from '../../config';
 import { db } from '../../db';
 import { publishEmoji } from '../../db/publishers';
 import { getUniqueEmojiName } from '../../db/queries/emojis';
 import { emojis } from '../../db/schema';
 import { enqueueActivityLog } from '../../queues/activity-log';
 import { fileManager } from '../../utils/file-manager';
-import { protectedProcedure } from '../../utils/trpc';
+import { protectedProcedure, rateLimitedProcedure } from '../../utils/trpc';
 
-const addEmojiRoute = protectedProcedure
+const addEmojiRoute = rateLimitedProcedure(protectedProcedure, {
+  maxRequests: config.rateLimiters.addEmoji.maxRequests,
+  windowMs: config.rateLimiters.addEmoji.windowMs,
+  logLabel: 'addEmoji'
+})
   .input(
     z.array(
       z.object({

--- a/apps/server/src/routers/messages/get-messages.ts
+++ b/apps/server/src/routers/messages/get-messages.ts
@@ -7,6 +7,7 @@ import {
 import { and, count, desc, eq, gte, inArray, isNull, lt } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/sqlite-core';
 import { z } from 'zod';
+import { config } from '../../config';
 import { db } from '../../db';
 import { getChannelsReadStatesForUser } from '../../db/queries/channels';
 import { assertDmChannel } from '../../db/queries/dms';
@@ -14,9 +15,13 @@ import { joinMessagesWithRelations } from '../../db/queries/messages';
 import { channelReadStates, channels, messages } from '../../db/schema';
 import { invariant } from '../../utils/invariant';
 import { pubsub } from '../../utils/pubsub';
-import { protectedProcedure } from '../../utils/trpc';
+import { protectedProcedure, rateLimitedProcedure } from '../../utils/trpc';
 
-const getMessagesRoute = protectedProcedure
+const getMessagesRoute = rateLimitedProcedure(protectedProcedure, {
+  maxRequests: config.rateLimiters.getMessages.maxRequests,
+  windowMs: config.rateLimiters.getMessages.windowMs,
+  logLabel: 'getMessages'
+})
   .input(
     z.object({
       channelId: z.number(),

--- a/apps/server/src/routers/messages/signal-typing.ts
+++ b/apps/server/src/routers/messages/signal-typing.ts
@@ -1,10 +1,15 @@
 import { ChannelPermission, Permission, ServerEvents } from '@sharkord/shared';
 import { z } from 'zod';
+import { config } from '../../config';
 import { getAffectedOnlineUserIdsForChannel } from '../../db/queries/channels';
 import { assertDmChannel } from '../../db/queries/dms';
-import { protectedProcedure } from '../../utils/trpc';
+import { protectedProcedure, rateLimitedProcedure } from '../../utils/trpc';
 
-const signalTypingRoute = protectedProcedure
+const signalTypingRoute = rateLimitedProcedure(protectedProcedure, {
+  maxRequests: config.rateLimiters.signalTyping.maxRequests,
+  windowMs: config.rateLimiters.signalTyping.windowMs,
+  logLabel: 'signalTyping'
+})
   .input(
     z.object({
       channelId: z.number(),

--- a/apps/server/src/routers/messages/toggle-message-reaction.ts
+++ b/apps/server/src/routers/messages/toggle-message-reaction.ts
@@ -1,6 +1,7 @@
 import { Permission } from '@sharkord/shared';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
+import { config } from '../../config';
 import { db } from '../../db';
 import { publishMessage } from '../../db/publishers';
 import { assertDmChannel } from '../../db/queries/dms';
@@ -8,9 +9,13 @@ import { getEmojiFileIdByEmojiName } from '../../db/queries/emojis';
 import { getReaction } from '../../db/queries/messages';
 import { messageReactions, messages } from '../../db/schema';
 import { invariant } from '../../utils/invariant';
-import { protectedProcedure } from '../../utils/trpc';
+import { protectedProcedure, rateLimitedProcedure } from '../../utils/trpc';
 
-const toggleMessageReactionRoute = protectedProcedure
+const toggleMessageReactionRoute = rateLimitedProcedure(protectedProcedure, {
+  maxRequests: config.rateLimiters.toggleMessageReaction.maxRequests,
+  windowMs: config.rateLimiters.toggleMessageReaction.windowMs,
+  logLabel: 'toggleMessageReaction'
+})
   .input(
     z.object({
       messageId: z.number(),

--- a/apps/server/src/routers/others/handshake.ts
+++ b/apps/server/src/routers/others/handshake.ts
@@ -1,9 +1,14 @@
 import { randomUUIDv7 } from 'bun';
+import { config } from '../../config';
 import { getSettings } from '../../db/queries/server';
 import { shouldAskServerPassword } from '../../helpers/should-ask-server-password';
-import { publicProcedure } from '../../utils/trpc';
+import { publicProcedure, rateLimitedProcedure } from '../../utils/trpc';
 
-const handshakeRoute = publicProcedure.query(async ({ ctx }) => {
+const handshakeRoute = rateLimitedProcedure(publicProcedure, {
+  maxRequests: config.rateLimiters.handshake.maxRequests,
+  windowMs: config.rateLimiters.handshake.windowMs,
+  logLabel: 'handshake'
+}).query(async ({ ctx }) => {
   const settings = await getSettings();
   const handshakeHash = randomUUIDv7();
   const shouldAskForPassword = await shouldAskServerPassword(ctx.user.id, {


### PR DESCRIPTION
### Problem
Several tRPC endpoints had no server-side rate limit, making them viable DoS vectors. Any authenticated client connecting directly over WebSocket could bypass the official client's UI flow and call them in a tight loop, generating thousands of SQLite queries per second against a single-writer database.

### Fix
Wrap each affected endpoint with the existing `rateLimitedProcedure` infrastructure. All limits are added to `config.rateLimiters.*` so they can be tuned via `config.ini` without touching code.

| Endpoint | Limit (per IP) | Rationale |
|---|---|---|
| `messages.signalTyping` | 40 / 5 s | Legitimate max at `TYPING_MS = 300 ms` is ~16/5 s. Cap gives ~2.5× headroom and accounts for multiple typists behind a shared NAT. |
| `messages.getMessages` | 60 / 10 s | Heaviest read endpoint (~7 queries + JOINs + pubsub). Cap comfortably covers rapid channel-switching and scroll pagination. |
| `messages.toggleMessageReaction` | 60 / 10 s | 4 queries per call; same threat profile as `signalTyping`. |
| `channels.markAsRead` | 60 / 10 s | 3 queries per call; triggered naturally by channel-switching. |
| `dms.openDirectMessage` | 10 / 60 s | Creates persistent state + publishes permission events; called at most a few times per session legitimately. |
| `emojis.addEmoji` | 10 / 60 s | Loops on `fileManager.saveFile` + DB insert per array element with no upper bound; admin-gated but still unbounded. |
| `others.handshake` | 10 / 60 s | Only `publicProcedure` — reachable pre-auth with no prior limit. |

The chosen rates are a starting point and may need tuning in real deployments, particularly for the navigation endpoints on servers where many users share an IP. Treat them as debatable.

Some unprotected endpoints were intentionally left out: those gated behind admin permissions (limited blast radius), low-cost single-lookup queries (not worth the noise), and endpoints whose cost lives inside a delegated subsystem where the right place to throttle isn't the tRPC layer.

Closes #722