### PR TITLE
fix(733): prevent non-owners from removing the owner role

### DIFF
--- a/apps/server/src/routers/__tests__/users.test.ts
+++ b/apps/server/src/routers/__tests__/users.test.ts
@@ -647,6 +647,36 @@ describe('users router', () => {
     );
   });
 
+  test('should throw when non-owner user tries to remove owner role from someone else', async () => {
+    const { caller } = await initTest();
+    const newRoleId = await caller.roles.add();
+
+    await caller.roles.update({
+      roleId: newRoleId,
+      name: 'Test Role',
+      color: '#123456',
+      permissions: [Permission.MANAGE_USERS],
+      storageQuotaOverrideEnabled: false,
+      storageSpaceQuota: 0
+    });
+
+    await caller.users.addRole({
+      userId: 2,
+      roleId: newRoleId
+    });
+
+    const { caller: nonOwnerCaller } = await initTest(2);
+
+    await expect(
+      nonOwnerCaller.users.removeRole({
+        userId: 1,
+        roleId: OWNER_ROLE_ID
+      })
+    ).rejects.toThrow(
+      'Only users with the owner role can remove the owner role'
+    );
+  });
+
   test('should throw when removing non-existent role', async () => {
     const { caller } = await initTest();
 

--- a/apps/server/src/routers/users/add-role.ts
+++ b/apps/server/src/routers/users/add-role.ts
@@ -1,12 +1,12 @@
-import { OWNER_ROLE_ID, Permission } from '@sharkord/shared';
+import { Permission } from '@sharkord/shared';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../../db';
 import { publishUser } from '../../db/publishers';
-import { getUserRoleIds } from '../../db/queries/roles';
 import { userRoles } from '../../db/schema';
 import { invariant } from '../../utils/invariant';
 import { protectedProcedure } from '../../utils/trpc';
+import { assertCanModifyOwnerRole } from './assert-can-modify-owner-role';
 
 const addRoleRoute = protectedProcedure
   .input(
@@ -33,15 +33,7 @@ const addRoleRoute = protectedProcedure
       message: 'User already has this role'
     });
 
-    const assingingUserRoles = await getUserRoleIds(ctx.userId);
-    const hasOwnerRole = assingingUserRoles.includes(OWNER_ROLE_ID);
-
-    if (!hasOwnerRole && input.roleId === OWNER_ROLE_ID) {
-      invariant(false, {
-        code: 'FORBIDDEN',
-        message: 'Only users with the owner role can assign the owner role'
-      });
-    }
+    await assertCanModifyOwnerRole(ctx.userId, input.roleId, 'assign');
 
     await db.insert(userRoles).values({
       userId: input.userId,

--- a/apps/server/src/routers/users/assert-can-modify-owner-role.ts
+++ b/apps/server/src/routers/users/assert-can-modify-owner-role.ts
@@ -1,0 +1,20 @@
+import { OWNER_ROLE_ID } from '@sharkord/shared';
+import { getUserRoleIds } from '../../db/queries/roles';
+import { invariant } from '../../utils/invariant';
+
+const assertCanModifyOwnerRole = async (
+  actorUserId: number,
+  roleId: number,
+  action: 'assign' | 'remove'
+) => {
+  if (roleId !== OWNER_ROLE_ID) return;
+
+  const actorRoleIds = await getUserRoleIds(actorUserId);
+
+  invariant(actorRoleIds.includes(OWNER_ROLE_ID), {
+    code: 'FORBIDDEN',
+    message: `Only users with the owner role can ${action} the owner role`
+  });
+};
+
+export { assertCanModifyOwnerRole };

--- a/apps/server/src/routers/users/remove-role.ts
+++ b/apps/server/src/routers/users/remove-role.ts
@@ -6,6 +6,7 @@ import { publishUser } from '../../db/publishers';
 import { userRoles } from '../../db/schema';
 import { invariant } from '../../utils/invariant';
 import { protectedProcedure } from '../../utils/trpc';
+import { assertCanModifyOwnerRole } from './assert-can-modify-owner-role';
 
 const removeRoleRoute = protectedProcedure
   .input(
@@ -16,6 +17,8 @@ const removeRoleRoute = protectedProcedure
   )
   .mutation(async ({ ctx, input }) => {
     await ctx.needsPermission(Permission.MANAGE_USERS);
+
+    await assertCanModifyOwnerRole(ctx.userId, input.roleId, 'remove');
 
     const existing = await db
       .select()


### PR DESCRIPTION
Closes #733 

Assumed bug: `users.addRole` already blocks non-owners from assigning the owner role, but `users.removeRole` has no equivalent check. As-is, any moderator with `MANAGE_USERS` can revoke the owner role from every owner in the server, leaving it ownerless and making themselves the de-facto owner if no other users hold moderation-tier roles.

This PR mirrors the addRole check in removeRole and extracts the shared rule into a small `assertCanModifyOwnerRole` helper consumed by both routes. Regression test added.