### PR TITLE
fix(737): enforce VIEW_CHANNEL on per-message, file and channel actions

### DIFF
--- a/apps/server/src/helpers/assert-channel-access.ts
+++ b/apps/server/src/helpers/assert-channel-access.ts
@@ -1,0 +1,15 @@
+import { ChannelPermission } from '@sharkord/shared';
+import { assertDmChannel } from '../db/queries/dms';
+import type { Context } from '../utils/trpc';
+
+const assertChannelAccess = async (
+  ctx: Context,
+  channelId: number
+): Promise<void> => {
+  await Promise.all([
+    assertDmChannel(channelId, ctx.userId),
+    ctx.needsChannelPermission(channelId, ChannelPermission.VIEW_CHANNEL)
+  ]);
+};
+
+export { assertChannelAccess };

--- a/apps/server/src/routers/channels/mark-as-read.ts
+++ b/apps/server/src/routers/channels/mark-as-read.ts
@@ -3,8 +3,8 @@ import { and, desc, eq, isNull } from 'drizzle-orm';
 import { z } from 'zod';
 import { config } from '../../config';
 import { db } from '../../db';
-import { assertDmChannel } from '../../db/queries/dms';
 import { channelReadStates, messages } from '../../db/schema';
+import { assertChannelAccess } from '../../helpers/assert-channel-access';
 import { protectedProcedure, rateLimitedProcedure } from '../../utils/trpc';
 
 const markAsReadRoute = rateLimitedProcedure(protectedProcedure, {
@@ -18,7 +18,7 @@ const markAsReadRoute = rateLimitedProcedure(protectedProcedure, {
     })
   )
   .mutation(async ({ ctx, input }) => {
-    await assertDmChannel(input.channelId, ctx.userId);
+    await assertChannelAccess(ctx, input.channelId);
 
     const { channelId } = input;
 

--- a/apps/server/src/routers/files/delete-file.ts
+++ b/apps/server/src/routers/files/delete-file.ts
@@ -7,6 +7,7 @@ import { publishMessage } from '../../db/publishers';
 import { getFilesByMessageId } from '../../db/queries/files';
 import { getMessageByFileId } from '../../db/queries/messages';
 import { messages } from '../../db/schema';
+import { assertChannelAccess } from '../../helpers/assert-channel-access';
 import { eventBus } from '../../plugins/event-bus';
 import { invariant } from '../../utils/invariant';
 import { protectedProcedure } from '../../utils/trpc';
@@ -20,6 +21,8 @@ const deleteFileRoute = protectedProcedure
       code: 'NOT_FOUND',
       message: 'Message not found'
     });
+
+    await assertChannelAccess(ctx, message.channelId);
 
     invariant(
       message.userId === ctx.user.id ||

--- a/apps/server/src/routers/messages/delete-message.ts
+++ b/apps/server/src/routers/messages/delete-message.ts
@@ -4,9 +4,9 @@ import { z } from 'zod';
 import { db } from '../../db';
 import { removeFile } from '../../db/mutations/files';
 import { publishMessage, publishReplyCount } from '../../db/publishers';
-import { assertDmChannel } from '../../db/queries/dms';
 import { getFilesByMessageId } from '../../db/queries/files';
 import { messages } from '../../db/schema';
+import { assertChannelAccess } from '../../helpers/assert-channel-access';
 import { eventBus } from '../../plugins/event-bus';
 import { invariant } from '../../utils/invariant';
 import { protectedProcedure } from '../../utils/trpc';
@@ -30,7 +30,7 @@ const deleteMessageRoute = protectedProcedure
       message: 'Message not found'
     });
 
-    await assertDmChannel(targetMessage.channelId, ctx.userId);
+    await assertChannelAccess(ctx, targetMessage.channelId);
 
     invariant(
       targetMessage.userId === ctx.user.id ||

--- a/apps/server/src/routers/messages/edit-message.ts
+++ b/apps/server/src/routers/messages/edit-message.ts
@@ -8,8 +8,8 @@ import { z } from 'zod';
 import { config } from '../../config';
 import { db } from '../../db';
 import { publishMessage } from '../../db/publishers';
-import { assertDmChannel } from '../../db/queries/dms';
 import { messages } from '../../db/schema';
+import { assertChannelAccess } from '../../helpers/assert-channel-access';
 import { sanitizeMessageHtml } from '../../helpers/sanitize-html';
 import { eventBus } from '../../plugins/event-bus';
 import { enqueueProcessMetadata } from '../../queues/message-metadata';
@@ -45,7 +45,7 @@ const editMessageRoute = rateLimitedProcedure(protectedProcedure, {
       message: 'Message not found'
     });
 
-    await assertDmChannel(message.channelId, ctx.userId);
+    await assertChannelAccess(ctx, message.channelId);
 
     invariant(message.editable, {
       code: 'FORBIDDEN',

--- a/apps/server/src/routers/messages/get-message.ts
+++ b/apps/server/src/routers/messages/get-message.ts
@@ -1,7 +1,6 @@
-import { ChannelPermission } from '@sharkord/shared';
 import { z } from 'zod';
-import { assertDmChannel } from '../../db/queries/dms';
 import { getMessage } from '../../db/queries/messages';
+import { assertChannelAccess } from '../../helpers/assert-channel-access';
 import { invariant } from '../../utils/invariant';
 import { protectedProcedure } from '../../utils/trpc';
 
@@ -19,12 +18,7 @@ const getMessageRoute = protectedProcedure
       message: 'Message not found'
     });
 
-    await assertDmChannel(message.channelId, ctx.userId);
-
-    await ctx.needsChannelPermission(
-      message.channelId,
-      ChannelPermission.VIEW_CHANNEL
-    );
+    await assertChannelAccess(ctx, message.channelId);
 
     return message;
   });

--- a/apps/server/src/routers/messages/get-messages.ts
+++ b/apps/server/src/routers/messages/get-messages.ts
@@ -1,5 +1,4 @@
 import {
-  ChannelPermission,
   DEFAULT_MESSAGES_LIMIT,
   ServerEvents,
   type TMessage
@@ -10,9 +9,9 @@ import { z } from 'zod';
 import { config } from '../../config';
 import { db } from '../../db';
 import { getChannelsReadStatesForUser } from '../../db/queries/channels';
-import { assertDmChannel } from '../../db/queries/dms';
 import { joinMessagesWithRelations } from '../../db/queries/messages';
 import { channelReadStates, channels, messages } from '../../db/schema';
+import { assertChannelAccess } from '../../helpers/assert-channel-access';
 import { invariant } from '../../utils/invariant';
 import { pubsub } from '../../utils/pubsub';
 import { protectedProcedure, rateLimitedProcedure } from '../../utils/trpc';
@@ -32,13 +31,7 @@ const getMessagesRoute = rateLimitedProcedure(protectedProcedure, {
   )
   .meta({ infinite: true })
   .query(async ({ ctx, input }) => {
-    await Promise.all([
-      assertDmChannel(input.channelId, ctx.userId),
-      ctx.needsChannelPermission(
-        input.channelId,
-        ChannelPermission.VIEW_CHANNEL
-      )
-    ]);
+    await assertChannelAccess(ctx, input.channelId);
 
     const { channelId, cursor, limit, targetMessageId } = input;
 

--- a/apps/server/src/routers/messages/get-pinned.ts
+++ b/apps/server/src/routers/messages/get-pinned.ts
@@ -1,10 +1,9 @@
-import { ChannelPermission } from '@sharkord/shared';
 import { and, desc, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../../db';
-import { assertDmChannel } from '../../db/queries/dms';
 import { joinMessagesWithRelations } from '../../db/queries/messages';
 import { channels, messages } from '../../db/schema';
+import { assertChannelAccess } from '../../helpers/assert-channel-access';
 import { invariant } from '../../utils/invariant';
 import { protectedProcedure } from '../../utils/trpc';
 
@@ -15,13 +14,7 @@ const getPinnedRoute = protectedProcedure
     })
   )
   .query(async ({ ctx, input }) => {
-    await Promise.all([
-      assertDmChannel(input.channelId, ctx.userId),
-      ctx.needsChannelPermission(
-        input.channelId,
-        ChannelPermission.VIEW_CHANNEL
-      )
-    ]);
+    await assertChannelAccess(ctx, input.channelId);
 
     const channel = await db
       .select({

--- a/apps/server/src/routers/messages/get-thread-messages.ts
+++ b/apps/server/src/routers/messages/get-thread-messages.ts
@@ -1,14 +1,10 @@
-import {
-  ChannelPermission,
-  DEFAULT_MESSAGES_LIMIT,
-  type TMessage
-} from '@sharkord/shared';
+import { DEFAULT_MESSAGES_LIMIT, type TMessage } from '@sharkord/shared';
 import { and, asc, eq, gt } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../../db';
-import { assertDmChannel } from '../../db/queries/dms';
 import { joinMessagesWithRelations } from '../../db/queries/messages';
 import { channels, messages } from '../../db/schema';
+import { assertChannelAccess } from '../../helpers/assert-channel-access';
 import { invariant } from '../../utils/invariant';
 import { protectedProcedure } from '../../utils/trpc';
 
@@ -41,13 +37,7 @@ const getThreadMessagesRoute = protectedProcedure
       message: 'Cannot get thread for a reply message'
     });
 
-    await Promise.all([
-      assertDmChannel(parentMessage.channelId, ctx.userId),
-      ctx.needsChannelPermission(
-        parentMessage.channelId,
-        ChannelPermission.VIEW_CHANNEL
-      )
-    ]);
+    await assertChannelAccess(ctx, parentMessage.channelId);
 
     const channel = await db
       .select({

--- a/apps/server/src/routers/messages/toggle-message-pin.ts
+++ b/apps/server/src/routers/messages/toggle-message-pin.ts
@@ -3,8 +3,8 @@ import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../../db';
 import { publishMessage } from '../../db/publishers';
-import { assertDmChannel } from '../../db/queries/dms';
 import { messages } from '../../db/schema';
+import { assertChannelAccess } from '../../helpers/assert-channel-access';
 import { enqueueActivityLog } from '../../queues/activity-log';
 import { invariant } from '../../utils/invariant';
 import { protectedProcedure } from '../../utils/trpc';
@@ -29,7 +29,7 @@ const toggleMessagePinRoute = protectedProcedure
       message: 'Message not found'
     });
 
-    await assertDmChannel(message.channelId, ctx.userId);
+    await assertChannelAccess(ctx, message.channelId);
 
     invariant(!message.parentMessageId, {
       code: 'BAD_REQUEST',

--- a/apps/server/src/routers/messages/toggle-message-reaction.ts
+++ b/apps/server/src/routers/messages/toggle-message-reaction.ts
@@ -4,10 +4,10 @@ import { z } from 'zod';
 import { config } from '../../config';
 import { db } from '../../db';
 import { publishMessage } from '../../db/publishers';
-import { assertDmChannel } from '../../db/queries/dms';
 import { getEmojiFileIdByEmojiName } from '../../db/queries/emojis';
 import { getReaction } from '../../db/queries/messages';
 import { messageReactions, messages } from '../../db/schema';
+import { assertChannelAccess } from '../../helpers/assert-channel-access';
 import { invariant } from '../../utils/invariant';
 import { protectedProcedure, rateLimitedProcedure } from '../../utils/trpc';
 
@@ -36,7 +36,7 @@ const toggleMessageReactionRoute = rateLimitedProcedure(protectedProcedure, {
       message: 'Message not found'
     });
 
-    await assertDmChannel(message.channelId, ctx.userId);
+    await assertChannelAccess(ctx, message.channelId);
 
     const reaction = await getReaction(
       input.messageId,


### PR DESCRIPTION
Six tRPC routes loaded resources by ID and only validated global permissions or authorship, without checking `ChannelPermission.VIEW_CHANNEL` on the target channel. Since `assertDmChannel` is a no-op for non-DM channels, a user holding the matching global permission (or the message author) could edit/delete messages, delete files, pin messages, react or mark-as-read on private channels they don't have access to. `files.delete` additionally allowed operating on DMs the user wasn't part of, because it never invoked `assertDmChannel` at all.

## Changes

- New helper `apps/server/src/helpers/assert-channel-access.ts` that runs `assertDmChannel` + `needsChannelPermission(VIEW_CHANNEL)` in parallel. Centralizes the rule "if you touch a channel by ID, validate access" in a single place.
- Add `assertChannelAccess(ctx, channelId)` to the six vulnerable routes:
  - `messages.edit`, `messages.delete`, `messages.togglePin`, `messages.toggleReaction`
  - `files.delete` (ordered: existence → access → authorship/moderation → mutation)
  - `channels.markAsRead`
- Refactor the four routes that already did the check by hand to use the helper: `messages.get`, `messages.getAll`, `messages.getPinned`, `messages.getThread`.

Closes #737 