### PR TITLE
fix(#763) update noise suppression to rnnoise

### DIFF
--- a/apps/client/src/components/devices-provider/index.tsx
+++ b/apps/client/src/components/devices-provider/index.tsx
@@ -29,7 +29,7 @@ const getDefaultDeviceSettings = (): TDeviceSettings => ({
   webcamResolution: Resolution['720p'],
   webcamFramerate: 30,
   echoCancellation: false,
-  noiseSuppression: NoiseSuppression.NONE,
+  noiseSuppression: NoiseSuppression.RNNOISE,
   autoGainControl: true,
   noiseGateEnabled: false,
   noiseGateThresholdDb: MICROPHONE_GATE_DEFAULT_THRESHOLD_DB,

--- a/apps/client/src/helpers/audio-worklet/rnnoise-worklet.ts
+++ b/apps/client/src/helpers/audio-worklet/rnnoise-worklet.ts
@@ -1,6 +1,5 @@
 const RNNOISE_WORKLET_URL = '/rnnoise/rnnoise-bundle.js';
 const RNNOISE_WORKLET_NAME = 'RnnoiseProcessor';
-const RNNOISE_SAMPLE_RATE = 48000;
 const RNNOISE_READY_TIMEOUT_MS = 10000;
 const RNNOISE_CACHE_NAME = 'rnnoise-worklet-v1';
 
@@ -93,16 +92,7 @@ const createRnnoiseChain = async (
     throw new Error('AudioWorklet is not supported in this browser');
   }
 
-  const nativeSampleRate =
-    inputStream.getAudioTracks()[0]?.getSettings().sampleRate ?? 48000;
-
-  if (nativeSampleRate !== RNNOISE_SAMPLE_RATE) {
-    throw new Error(
-      `RNNoise requires a 48kHz audio context (got ${nativeSampleRate}Hz)`
-    );
-  }
-
-  const ctx = new AudioContext({ sampleRate: nativeSampleRate });
+  const ctx = new AudioContext({ sampleRate: 48000 });
   await ensureWorkletLoaded(ctx);
 
   // outputChannelCount: [2] allocates a second output channel buffer so the


### PR DESCRIPTION
**Summary**
This PR enables RNNOISE noise suppression by default and simplifies the RNNoise audio worklet initialization by always using a 48kHz AudioContext.

**Changes**
1. **Enable RNNOISE as the default noise suppression.**
   - Changed the default device setting for `noiseSuppression` from `NoiseSuppression.NONE` to `NoiseSuppression.RNNOISE`, so new users get noise suppression out of the box.

2. **Simplify & harden RNNoise AudioContext setup.**
   - Removed the `RNNOISE_SAMPLE_RATE` constant and the logic that read the native sample rate from the input device's audio track (`getAudioTracks()[0]?.getSettings().sampleRate`).
   - Removed the runtime error throw when the native sample rate was not 48kHz — this was fragile since device-reported sample rates can vary or be unavailable.
   - The `AudioContext` is now always created with a hardcoded `sampleRate: 48000`, which is what RNNoise requires. This is more reliable and avoids unnecessary failures.

**Why this works:** 
The browser's `createMediaStreamSource` automatically resamples the microphone input to match the context. By forcing a 48kHz context, RNNoise is guaranteed its required sample rate regardless of the microphone's native hardware rate.

Closes #763