### PR TITLE
fix(#765): avatar rendering in the invite list

### DIFF
--- a/apps/client/src/components/server-screens/server-settings/invites/table-invite.tsx
+++ b/apps/client/src/components/server-screens/server-settings/invites/table-invite.tsx
@@ -132,7 +132,7 @@ const TableInvite = memo(({ invite, refetch }: TTableInviteProps) => {
       </div>
 
       <div className="flex items-center gap-2 min-w-0">
-        <UserAvatar userId={1} showUserPopover />
+        <UserAvatar userId={invite.creator.id} showUserPopover />
       </div>
 
       <div className="flex items-center text-muted-foreground">


### PR DESCRIPTION
## Summary

This PR fixes an issue where user avatars were not displayed in the invite list.

## Changes
Fixed avatar rendering in the invite list.

Closes #765 

## Additional Context

<img width="1104" height="365" alt="image" src="https://github.com/user-attachments/assets/cbab42fb-e223-4d79-862e-7a9bcfa85296" />

