### PR TITLE
feat: add server reconnection handling and remove stored credentials

### DIFF
--- a/apps/client/src/components/reconnecting-banner/index.tsx
+++ b/apps/client/src/components/reconnecting-banner/index.tsx
@@ -1,0 +1,19 @@
+import { Loader2 } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const ReconnectingBanner = memo(() => {
+  const { t } = useTranslation('common');
+
+  return (
+    <div
+      role="status"
+      className="fixed top-0 inset-x-0 z-50 flex items-center justify-center gap-2 bg-yellow-500/90 px-4 py-1.5 text-sm font-medium text-black"
+    >
+      <Loader2 className="h-4 w-4 animate-spin" />
+      {t('reconnecting')}
+    </div>
+  );
+});
+
+export { ReconnectingBanner };

--- a/apps/client/src/components/routing/auto-login-controller.tsx
+++ b/apps/client/src/components/routing/auto-login-controller.tsx
@@ -11,6 +11,7 @@ import {
   setLocalStorageItemBool,
   setSessionStorageItem
 } from '@/helpers/storage';
+import { cleanup } from '@/lib/trpc';
 import { memo, useEffect, useRef } from 'react';
 
 const AutoLoginController = memo(() => {
@@ -50,6 +51,8 @@ const AutoLoginController = memo(() => {
 
     connect()
       .catch(() => {
+        cleanup();
+
         // token expired or invalid clear auto-login state so the user
         // sees the connect screen and can log in manually
         removeLocalStorageItem(LocalStorageKey.AUTO_LOGIN_TOKEN);

--- a/apps/client/src/components/routing/index.tsx
+++ b/apps/client/src/components/routing/index.tsx
@@ -1,3 +1,4 @@
+import { ReconnectingBanner } from '@/components/reconnecting-banner';
 import {
   useIsAppLoading,
   useIsAutoConnecting,
@@ -6,6 +7,7 @@ import {
 import {
   useDisconnectInfo,
   useIsConnected,
+  useIsReconnecting,
   useServerName
 } from '@/features/server/hooks';
 import { Connect } from '@/screens/connect';
@@ -24,6 +26,7 @@ const Routing = memo(() => {
   const disconnectInfo = useDisconnectInfo();
   const serverName = useServerName();
   const isAutoConnecting = useIsAutoConnecting();
+  const isReconnecting = useIsReconnecting();
 
   useEffect(() => {
     if (isConnected && serverName) {
@@ -40,7 +43,7 @@ const Routing = memo(() => {
     );
   }
 
-  if (!isConnected) {
+  if (!isConnected && !isReconnecting) {
     if (isAutoConnecting) {
       return <LoadingApp text={t('loggingInAutomatically')} />;
     }
@@ -57,7 +60,12 @@ const Routing = memo(() => {
     return <Connect />;
   }
 
-  return <ServerView />;
+  return (
+    <>
+      {isReconnecting && <ReconnectingBanner />}
+      <ServerView />
+    </>
+  );
 });
 
 export { Routing };

--- a/apps/client/src/features/server/actions.ts
+++ b/apps/client/src/features/server/actions.ts
@@ -4,6 +4,7 @@ import { getHostFromServer } from '@/helpers/get-file-url';
 import { cleanup, connectToTRPC, getTRPCClient } from '@/lib/trpc';
 import type { TMessageJumpToTarget } from '@/types';
 import { type TPublicServerSettings, type TServerInfo } from '@sharkord/shared';
+import { TRPCClientError } from '@trpc/client';
 import { toast } from 'sonner';
 import { appSliceActions } from '../app/slice';
 import { openDialog } from '../dialogs/actions';
@@ -57,6 +58,65 @@ export const setInfo = (info: TServerInfo | undefined) => {
   store.dispatch(serverSliceActions.setInfo(info));
 };
 
+const RECONNECT_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 8_000];
+
+let reconnectAttempt = 0;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let reconnectDisconnectInfo: TDisconnectInfo | undefined;
+
+export const cancelReconnect = () => {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+
+  reconnectAttempt = 0;
+  reconnectDisconnectInfo = undefined;
+};
+
+const abandonReconnect = () => {
+  const info = reconnectDisconnectInfo;
+
+  cleanup();
+  setDisconnectInfo(info);
+};
+
+export const reconnectToServer = (info: TDisconnectInfo) => {
+  if (reconnectTimer) return;
+
+  reconnectDisconnectInfo = info;
+
+  const delay = RECONNECT_DELAYS_MS[reconnectAttempt];
+
+  if (delay === undefined) {
+    abandonReconnect();
+    return;
+  }
+
+  reconnectAttempt += 1;
+  store.dispatch(serverSliceActions.setReconnecting(true));
+
+  reconnectTimer = setTimeout(async () => {
+    reconnectTimer = null;
+
+    try {
+      await connect();
+      cancelReconnect();
+    } catch (error) {
+      if (
+        error instanceof TRPCClientError &&
+        (error.data?.code === 'UNAUTHORIZED' ||
+          error.data?.code === 'FORBIDDEN')
+      ) {
+        abandonReconnect();
+        return;
+      }
+
+      reconnectToServer(info);
+    }
+  }, delay);
+};
+
 export const setActiveFullscreenPluginId = (pluginId: string | undefined) => {
   store.dispatch(serverSliceActions.setActiveFullscreenPluginId(pluginId));
 };
@@ -97,9 +157,11 @@ export const joinServer = async (handshakeHash: string, password?: string) => {
 
   const { initSubscriptions } = await import('./subscriptions');
 
+  unsubscribeFromServer?.();
   unsubscribeFromServer = initSubscriptions();
 
   store.dispatch(serverSliceActions.setInitialData(data));
+  setDisconnectInfo(undefined);
 
   setPluginCommands(data.commands);
 

--- a/apps/client/src/features/server/hooks.ts
+++ b/apps/client/src/features/server/hooks.ts
@@ -21,6 +21,7 @@ import {
   ownVoiceUserSelector,
   pluginsEnabledSelector,
   publicServerSettingsSelector,
+  reconnectingSelector,
   referenceableChannelsSelector,
   serverNameSelector,
   typingUsersByChannelIdSelector,
@@ -31,6 +32,8 @@ import {
 } from './selectors';
 
 export const useIsConnected = () => useSelector(connectedSelector);
+
+export const useIsReconnecting = () => useSelector(reconnectingSelector);
 
 export const useIsConnecting = () => useSelector(connectingSelector);
 

--- a/apps/client/src/features/server/selectors.ts
+++ b/apps/client/src/features/server/selectors.ts
@@ -30,6 +30,9 @@ import { voiceChannelStateSelector } from './voice/selectors';
 
 export const connectedSelector = (state: IRootState) => state.server.connected;
 
+export const reconnectingSelector = (state: IRootState) =>
+  state.server.reconnecting;
+
 export const disconnectInfoSelector = (state: IRootState) =>
   state.server.disconnectInfo;
 

--- a/apps/client/src/features/server/slice.ts
+++ b/apps/client/src/features/server/slice.ts
@@ -32,6 +32,7 @@ import type {
 export interface IServerState {
   connected: boolean;
   connecting: boolean;
+  reconnecting: boolean;
   disconnectInfo?: TDisconnectInfo;
   serverId?: string;
   categories: TCategory[];
@@ -75,6 +76,7 @@ export interface IServerState {
 const initialState: IServerState = {
   connected: false,
   connecting: false,
+  reconnecting: false,
   disconnectInfo: undefined,
   serverId: undefined,
   ownUserId: undefined,
@@ -146,6 +148,9 @@ export const serverSlice = createSlice({
     setServerId: (state, action: PayloadAction<string | undefined>) => {
       state.serverId = action.payload;
     },
+    setReconnecting: (state, action: PayloadAction<boolean>) => {
+      state.reconnecting = action.payload;
+    },
     setInfo: (state, action: PayloadAction<TServerInfo | undefined>) => {
       state.info = action.payload;
     },
@@ -177,6 +182,7 @@ export const serverSlice = createSlice({
       }>
     ) => {
       state.connected = true;
+      state.reconnecting = false;
       state.categories = action.payload.categories;
       state.channels = action.payload.channels;
       state.emojis = action.payload.emojis;

--- a/apps/client/src/helpers/storage.ts
+++ b/apps/client/src/helpers/storage.ts
@@ -1,8 +1,5 @@
 export enum LocalStorageKey {
   IDENTITY = 'sharkord-identity',
-  REMEMBER_CREDENTIALS = 'sharkord-remember-identity',
-  USER_PASSWORD = 'sharkord-user-password',
-  SERVER_PASSWORD = 'sharkord-server-password',
   VITE_UI_THEME = 'vite-ui-theme',
   DEVICES_SETTINGS = 'sharkord-devices-settings',
   FLOATING_CARD_POSITION = 'sharkord-floating-card-position',

--- a/apps/client/src/i18n/locales/cs/common.json
+++ b/apps/client/src/i18n/locales/cs/common.json
@@ -84,5 +84,6 @@
   "searchResults": "Výsledky hledání ({{count}})",
   "wasReactedBy": "reagovali {{reacters}}.",
   "andMore": "a dalších {{count}}",
-  "toggleParticipants": "Zobrazit/skrýt účastníky"
+  "toggleParticipants": "Zobrazit/skrýt účastníky",
+  "reconnecting": "Opětovné připojování k serveru..."
 }

--- a/apps/client/src/i18n/locales/en/common.json
+++ b/apps/client/src/i18n/locales/en/common.json
@@ -86,5 +86,6 @@
   "andMore": "and {{count}} more",
   "typeAMessage": "Type a message...",
   "messageChannel": "Message \"{{name}}\"",
-  "toggleParticipants": "Show/hide participants"
+  "toggleParticipants": "Show/hide participants",
+  "reconnecting": "Reconnecting to the server..."
 }

--- a/apps/client/src/i18n/locales/es/common.json
+++ b/apps/client/src/i18n/locales/es/common.json
@@ -84,5 +84,6 @@
   "searchResults": "Resultados de búsqueda ({{count}})",
   "wasReactedBy": "ha sido reaccionado por {{reacters}}.",
   "andMore": "y {{count}} más",
-  "toggleParticipants": "Mostrar/ocultar participantes"
+  "toggleParticipants": "Mostrar/ocultar participantes",
+  "reconnecting": "Volviendo a conectar con el servidor..."
 }

--- a/apps/client/src/i18n/locales/fr/common.json
+++ b/apps/client/src/i18n/locales/fr/common.json
@@ -84,5 +84,6 @@
   "searchResults": "Résultats de la recherche ({{count}})",
   "wasReactedBy": "{{reacters}} a réagi.",
   "andMore": "et {{count}} autres",
-  "toggleParticipants": "Afficher/masquer les participants"
+  "toggleParticipants": "Afficher/masquer les participants",
+  "reconnecting": "Reconnexion au serveur..."
 }

--- a/apps/client/src/i18n/locales/it/common.json
+++ b/apps/client/src/i18n/locales/it/common.json
@@ -84,5 +84,6 @@
   "searchResults": "Risultati ricerca ({{count}})",
   "wasReactedBy": "ha ricevuto una reazione da {{reacters}}.",
   "andMore": "e altri {{count}}",
-  "toggleParticipants": "Mostra/nascondi partecipanti"
+  "toggleParticipants": "Mostra/nascondi partecipanti",
+  "reconnecting": "Riconnessione al server..."
 }

--- a/apps/client/src/i18n/locales/ru/common.json
+++ b/apps/client/src/i18n/locales/ru/common.json
@@ -84,5 +84,6 @@
   "searchResults": "Результаты поиска ({{count}})",
   "wasReactedBy": "на это отреагировали {{reacters}}.",
   "andMore": "и еще {{count}}",
-  "toggleParticipants": "Показать/скрыть участников"
+  "toggleParticipants": "Показать/скрыть участников",
+  "reconnecting": "Повторное подключение к серверу..."
 }

--- a/apps/client/src/i18n/locales/zh/common.json
+++ b/apps/client/src/i18n/locales/zh/common.json
@@ -84,5 +84,6 @@
   "searchResults": "搜索结果（{{count}}）",
   "wasReactedBy": "{{reacters}} 做出了反应。",
   "andMore": "以及其他 {{count}} 人",
-  "toggleParticipants": "显示/隐藏参与者"
+  "toggleParticipants": "显示/隐藏参与者",
+  "reconnecting": "正在重新连接服务器..."
 }

--- a/apps/client/src/lib/trpc.ts
+++ b/apps/client/src/lib/trpc.ts
@@ -1,7 +1,13 @@
 import { resetApp } from '@/features/app/actions';
 import { resetDialogs } from '@/features/dialogs/actions';
 import { resetServerScreens } from '@/features/server-screens/actions';
-import { resetServerState, setDisconnectInfo } from '@/features/server/actions';
+import {
+  cancelReconnect,
+  reconnectToServer,
+  resetServerState,
+  setConnected,
+  setDisconnectInfo
+} from '@/features/server/actions';
 import { playSound } from '@/features/server/sounds/actions';
 import { SoundType } from '@/features/server/types';
 import {
@@ -11,7 +17,11 @@ import {
   removeSessionStorageItem,
   SessionStorageKey
 } from '@/helpers/storage';
-import { type AppRouter, type TConnectionParams } from '@sharkord/shared';
+import {
+  DisconnectCode,
+  type AppRouter,
+  type TConnectionParams
+} from '@sharkord/shared';
 import { createTRPCProxyClient, createWSClient, wsLink } from '@trpc/client';
 
 let wsClient: ReturnType<typeof createWSClient> | null = null;
@@ -32,19 +42,33 @@ const initializeTRPC = (host: string) => {
   wsClient = createWSClient({
     url: `${protocol}://${host}`,
     // @ts-expect-error - the onclose type is not correct in trpc
-    onClose: (cause: CloseEvent) => {
-      cleanup();
+    onClose: (cause?: CloseEvent) => {
+      if (isNavigatingAway || isCleaningUp) return;
 
-      setDisconnectInfo({
-        code: cause.code,
-        reason: cause.reason,
-        wasClean: cause.wasClean,
+      const info = {
+        code: cause?.code ?? DisconnectCode.UNEXPECTED,
+        reason: cause?.reason ?? '',
+        wasClean: cause?.wasClean ?? false,
         time: new Date()
-      });
+      };
 
-      if (!cause.wasClean) {
-        playSound(SoundType.SERVER_DISCONNECTED);
+      if (
+        info.code === DisconnectCode.KICKED ||
+        info.code === DisconnectCode.BANNED
+      ) {
+        cleanup();
+        setDisconnectInfo(info);
+
+        if (!info.wasClean) {
+          playSound(SoundType.SERVER_DISCONNECTED);
+        }
+
+        return;
       }
+
+      closeClient();
+      setConnected(false);
+      reconnectToServer(info);
     },
     connectionParams: async (): Promise<TConnectionParams> => {
       return {
@@ -83,13 +107,7 @@ const getTRPCClient = () => {
   return trpc;
 };
 
-const cleanup = () => {
-  if (isCleaningUp) {
-    return;
-  }
-
-  isCleaningUp = true;
-
+const closeClient = () => {
   if (wsClient) {
     wsClient.close();
     wsClient = null;
@@ -97,6 +115,17 @@ const cleanup = () => {
 
   trpc = null;
   currentHost = null;
+};
+
+const cleanup = () => {
+  if (isCleaningUp) {
+    return;
+  }
+
+  isCleaningUp = true;
+
+  cancelReconnect();
+  closeClient();
 
   // cleanup can be called due to various reasons (manual disconnect, connection error, auto-login failure, etc).
   // so we remove any persisted auto-login token to prevent auto-login loops.

--- a/apps/client/src/screens/connect/index.tsx
+++ b/apps/client/src/screens/connect/index.tsx
@@ -38,14 +38,10 @@ const Connect = memo(() => {
   const { values, r, setErrors, onChange } = useForm<{
     identity: string;
     password: string;
-    rememberCredentials: boolean;
     autoLogin: boolean;
   }>({
     identity: getLocalStorageItem(LocalStorageKey.IDENTITY) || '',
-    password: getLocalStorageItem(LocalStorageKey.USER_PASSWORD) || '',
-    rememberCredentials: !!getLocalStorageItem(
-      LocalStorageKey.REMEMBER_CREDENTIALS
-    ),
+    password: '',
     autoLogin: getLocalStorageItemBool(LocalStorageKey.AUTO_LOGIN)
   });
 
@@ -86,6 +82,7 @@ const Connect = memo(() => {
       const data = (await response.json()) as { token: string };
 
       setSessionStorageItem(SessionStorageKey.TOKEN, data.token);
+      setLocalStorageItem(LocalStorageKey.IDENTITY, values.identity);
       setLocalStorageItemBool(LocalStorageKey.AUTO_LOGIN, values.autoLogin);
 
       if (values.autoLogin) {


### PR DESCRIPTION
## Summary

• Automatically retry unexpected server disconnects with backoff
• Show a reconnecting banner while preserving the current app view
• Stop storing user and server passwords locally
• Clean up WebSocket state after failed connections