### PR TITLE
fix: match disconnect button height in voice controls

### DIFF
--- a/apps/client/src/components/channel-view/voice/controls-bar.tsx
+++ b/apps/client/src/components/channel-view/voice/controls-bar.tsx
@@ -119,7 +119,7 @@ const ControlsBar = memo(({ channelId }: TControlsBarProps) => {
       <Tooltip content="Disconnect">
         <Button
           className={cn(
-            'inline-flex h-full min-w-11 items-center justify-center rounded px-3 border border-border',
+            'inline-flex h-auto self-stretch min-w-11 items-center justify-center rounded px-3 border border-border',
             'pointer-events-auto text-white shadow-xl transition-all',
             'bg-[#ec4245] hover:bg-[#da373c]'
           )}


### PR DESCRIPTION
## Summary

Sorry for not creating an issue

The disconnect button used `h-full`, which resolves to `auto` when the controls bar is absolutely positioned, so it shrank to its own content height with "always show voice controls" off. Replaced with `h-auto self-stretch` so it matches the controls group in both modes.

## Additional Context

### VIDEO: before / after


https://github.com/user-attachments/assets/9be66066-c091-4968-bcdb-df64befc5d46


https://github.com/user-attachments/assets/546d218f-5d06-4c5b-bbbc-2db96a2517e3

